### PR TITLE
Nodeを作成する関数をリファクタ

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -187,13 +187,12 @@ Node *unary()
     }
     else if (consume("&"))
     {
-        return new_node(ND_ADDR, unary(), NULL);
+        return new_node_single(ND_ADDR, unary());
     }
-
     else if (consume("*"))
     {
 
-        return new_node(ND_DEREF, unary(), NULL);
+        return new_node_single(ND_DEREF, unary());
     }
     return primary();
 }

--- a/parser.c
+++ b/parser.c
@@ -55,6 +55,24 @@ Node *new_node(NodeKind kind, Node *lhs, Node *rhs)
     return node;
 }
 
+Node *new_node_single(NodeKind kind, Node *lhs)
+{
+    Node *node = calloc(1, sizeof(Node));
+    node->kind = kind;
+    node->lhs = lhs;
+    Type *ty = calloc(1, sizeof(Node));
+    if (kind == ND_DEREF)
+        node->ty = lhs->ty->ptr_to;
+    else if (kind == ND_ADDR)
+    {
+        ty->ptr_to = lhs->ty;
+        ty->ty = PTR;
+        node->ty = ty;
+    }
+    else
+        node->ty = lhs->ty;
+}
+
 Node *new_node_num(int val)
 {
     Node *node = calloc(1, sizeof(Node));

--- a/parser.c
+++ b/parser.c
@@ -6,51 +6,25 @@ Node *new_node(NodeKind kind, Node *lhs, Node *rhs)
     node->kind = kind;
     node->lhs = lhs;
     node->rhs = rhs;
-
-    Type *ty = calloc(1, sizeof(Type));
-    if (lhs != NULL && rhs != NULL)
+    if (lhs->ty->ty == PTR && rhs->ty->ty == PTR)
     {
-        if (lhs->ty->ty == PTR && rhs->ty->ty == PTR)
-        {
-            if (kind != ND_ASSIGN)
-                error("式にはintが必要です");
-            // 右でも左でも一緒
-            node->ty = lhs->ty;
-        }
-        else if (lhs->ty->ty == INT && rhs->ty->ty == PTR)
-        {
-            node->ty = rhs->ty;
-        }
-        else if (lhs->ty->ty == PTR && rhs->ty->ty == INT)
-        {
-            node->ty = lhs->ty;
-        }
-        else if (lhs->ty->ty == INT && rhs->ty->ty == INT)
-        {
-            // 右でも左でも一緒
-            node->ty = lhs->ty;
-        }
+        if (kind != ND_ASSIGN)
+            error("式にはintが必要です");
+        // 右でも左でも一緒
+        node->ty = lhs->ty;
     }
-    else if (lhs != NULL && rhs == NULL)
-    {
-        if (kind == ND_DEREF)
-            node->ty = lhs->ty->ptr_to;
-        else if (kind == ND_ADDR)
-        {
-            ty->ptr_to = lhs->ty;
-            ty->ty = PTR;
-            node->ty = ty;
-        }
-        else
-            node->ty = lhs->ty;
-    }
-    else if (lhs == NULL && rhs != NULL)
+    else if (lhs->ty->ty == INT && rhs->ty->ty == PTR)
     {
         node->ty = rhs->ty;
     }
-    else
+    else if (lhs->ty->ty == PTR && rhs->ty->ty == INT)
     {
-        node->ty = NULL;
+        node->ty = lhs->ty;
+    }
+    else if (lhs->ty->ty == INT && rhs->ty->ty == INT)
+    {
+        // 右でも左でも一緒
+        node->ty = lhs->ty;
     }
     return node;
 }
@@ -308,12 +282,14 @@ Node *stmt()
     Node *node;
     if (consume("{"))
     {
-        Node *cur = new_node(ND_BLOCK, NULL, NULL);
+        Node *cur = calloc(1, sizeof(Node));
+        cur->kind = ND_BLOCK;
         node = cur;
         while (!consume("}"))
         {
             cur->lhs = stmt();
-            cur->rhs = new_node(ND_BLOCK, NULL, NULL);
+            cur->rhs = calloc(1, sizeof(Node));
+            cur->kind = ND_BLOCK;
             cur = cur->rhs;
         }
         return node;

--- a/parser.c
+++ b/parser.c
@@ -12,9 +12,6 @@ Node *new_node(NodeKind kind, Node *lhs, Node *rhs)
     {
     case ND_RETURN:
     case ND_BLOCK:
-    case ND_FUNC:
-    case ND_ARG:
-    case ND_FUNCDEF:
         return node;
     }
     Type *ty = calloc(1, sizeof(Type));

--- a/parser.c
+++ b/parser.c
@@ -393,7 +393,8 @@ Node *stmt()
 
 Node *func()
 {
-    Node *node = new_node(ND_FUNCDEF, NULL, NULL);
+    Node *node = calloc(1, sizeof(Node));
+    node->kind = ND_FUNCDEF;
     Token *tok = consume_ident();
 
     if (tok->length == 3 && strncmp(tok->string, "int", 3) == 0)

--- a/parser.c
+++ b/parser.c
@@ -10,7 +10,8 @@ Node *new_node(NodeKind kind, Node *lhs, Node *rhs)
     {
         if (kind != ND_ASSIGN)
             error("式にはintが必要です");
-        // 右でも左でも一緒
+        // TODO 代入式の両辺の型が等しいかチェックする
+        // -Wincompatible-pointer-typesというオプションらしい
         node->ty = lhs->ty;
     }
     else if (lhs->ty->ty == INT && rhs->ty->ty == PTR)

--- a/parser.c
+++ b/parser.c
@@ -138,7 +138,7 @@ Node *ident()
         {
             if (count > 0)
                 expect(",");
-            Node *arg = new_node(ND_ARG, expr(), NULL);
+            Node *arg = new_node_single(ND_ARG, expr());
             arg_top->rhs = arg;
             arg_top = arg;
             count++;

--- a/parser.c
+++ b/parser.c
@@ -321,7 +321,7 @@ Node *stmt()
     }
     else if (consume_return())
     {
-        node = new_node(ND_RETURN, expr(), NULL);
+        node = new_node_single(ND_RETURN, expr());
         expect(";");
     }
     else if (consume_if())

--- a/parser.c
+++ b/parser.c
@@ -7,13 +7,6 @@ Node *new_node(NodeKind kind, Node *lhs, Node *rhs)
     node->lhs = lhs;
     node->rhs = rhs;
 
-    // TODO ここのチェックはしなくていいようにリファクタしていく
-    switch (node->kind)
-    {
-    case ND_RETURN:
-    case ND_BLOCK:
-        return node;
-    }
     Type *ty = calloc(1, sizeof(Type));
     if (lhs != NULL && rhs != NULL)
     {


### PR DESCRIPTION
- ND_FUNCDEFを作る際にnew_nodeを使わない
- 不要なチェックを削除
- new_nodeの中の不要なチェックを削除
- 単一の子を持つNodeを作成する関数を実装
- ND_ARGをnew_node_singleで作成する
- ND_RETURNをnew_node_singleで作成する
- *と&をnew_node_singleで作成する
- new_nodeをsimplify
- add Comment
