### PR TITLE
update : passed failedの表示をかっこよくした

### DIFF
--- a/bin/hcc
+++ b/bin/hcc
@@ -43,12 +43,12 @@ elif [ $1 = "testv2dr" ]; then
         content=$(cat $fn)
         ./bin/exe.out "$content" >tmp.s
         cc -o tmp tmp.s helper/helper.c
-        echo $fn
+        printf $fn
         ./tmp
         if [ $? = 0 ]; then
-            echo "Test passed"
+            printf "...passed\n"
         else
-            echo "Test failed"
+            printf "...failed\n"
         fi
     done
     rm tmp.s tmp


### PR DESCRIPTION
echoの変わりにprintfを使うことで改行文字を勝手に入れないようにした。以下実行例
ex)
test/array.c...passed
test/calc.c...passed
test/ctrl.c...passed
test/fibo.c...passed
test/ptr.c...passed
test/sizeof.c...passed
