### PR TITLE
is_typeをconsume_typeで置き換え

### DIFF
--- a/hooligan.h
+++ b/hooligan.h
@@ -147,6 +147,7 @@ extern Vec *strings;
 void error(char *fmt, ...); // これutilのほうがいい
 bool consume(char *op);
 bool consume_rw(TokenKind tk);
+Type *consume_type();
 void expect(char *op);
 bool at_eof();
 bool istype(Token *tok, TypeKind ty); // consume_typeとかにできるかも？

--- a/hooligan.h
+++ b/hooligan.h
@@ -21,6 +21,8 @@ typedef enum
     TK_FOR,
     TK_WHILE,
     TK_SIZEOF,
+    TK_INT,
+    TK_CHAR,
     // add reserved word above
     TK_OPERATOR,
     TK_NUMBER,
@@ -150,7 +152,7 @@ bool consume_rw(TokenKind tk);
 Type *consume_type();
 void expect(char *op);
 bool at_eof();
-bool istype(Token *tok, TypeKind ty); // consume_typeとかにできるかも？
+
 
 // parser.c
 int expect_number();

--- a/parser.c
+++ b/parser.c
@@ -113,45 +113,27 @@ static Node *num()
 
 static Node *ident()
 {
-    Token *tok = consume_ident();
-    if (istype(tok, INT) || istype(tok, CHAR))
+    Type *ty = consume_type();
+    Token *ident = consume_ident();
+    if (ty)
     {
-        Type *ty;
-
-        if (istype(tok, INT))
-        {
-            ty = new_type_int();
-        }
-        else if (istype(tok, CHAR))
-        {
-            ty = new_type_char();
-        }
-        else
-        {
-            error("定義されていない型です");
-        }
-        while (consume("*"))
-        {
-            ty = new_type_ptr(ty);
-        }
-        tok = consume_ident();
         if (consume("["))
         {
             int size = expect_number();
             ty = new_type_array(ty, size);
             expect("]");
-            int offset = def_var(tok, ty, true);
+            int offset = def_var(ident, ty, true);
             return new_node_var(offset, ty);
         }
         else
         {
-            int offset = def_var(tok, ty, true);
+            int offset = def_var(ident, ty, true);
             return new_node_var(offset, ty);
         }
     }
     if (consume("("))
     {
-        Node *node = new_node_func(tok->string, tok->length);
+        Node *node = new_node_func(ident->string, ident->length);
         Node *arg_top = node;
         int count = 0;
         while (!consume(")"))
@@ -168,14 +150,14 @@ static Node *ident()
     else
     {
         int offset;
-        Var *lvar = find_var(tok, true);
+        Var *lvar = find_var(ident, true);
         if (lvar)
             offset = lvar->offset;
         else
         {
-            Var *gvar = find_var(tok, false);
+            Var *gvar = find_var(ident, false);
             if (gvar)
-                return new_node_glob_var(tok, gvar->ty);
+                return new_node_glob_var(ident, gvar->ty);
             else
                 error("変数が定義されていません");
         }

--- a/parser.c
+++ b/parser.c
@@ -445,19 +445,10 @@ static Node *func(Token *ident, Type *ty)
             error("引数の数が多すぎます");
         if (arg_count != 1)
             expect(",");
-        Token *arg_token = consume_ident();
-        Type *arg_ty = new_type_int();
-        if (istype(arg_token, INT))
-        {
-            while (consume("*"))
-            {
-                arg_ty = new_type_ptr(arg_ty);
-            }
-
-            arg_token = consume_ident();
-        }
-        else
+        Type *arg_ty = consume_type();
+        if (!arg_ty)
             error("引数に型がありません");
+        Token *arg_token = consume_ident();
         int offset = def_var(arg_token, arg_ty, true);
         Node *arg = new_node_var(offset, arg_ty);
         arg_top->lhs = arg;
@@ -485,26 +476,15 @@ static Node *glob_var(Token *ident, Type *ty)
 
 static Node *def()
 {
-    Token *tok = consume_ident();
-    Type *ty = new_type_int();
-
-    if (istype(tok, INT))
-    {
-        while (consume("*"))
-        {
-            ty = new_type_ptr(ty);
-        }
-
-        tok = consume_ident();
-    }
-    else
-    {
+    Type *ty = consume_type();
+    if (!ty)
         error("定義式に型がありません");
-    }
+
+    Token *ident = consume_ident();
     Node *node;
     if (consume("("))
     {
-        node = func(tok, ty);
+        node = func(ident, ty);
     }
     else
     {
@@ -515,7 +495,7 @@ static Node *def()
             ty = new_type_array(ty, size);
             expect("]");
         }
-        node = glob_var(tok, ty);
+        node = glob_var(ident, ty);
     }
 
     return node;

--- a/parser.c
+++ b/parser.c
@@ -174,13 +174,13 @@ static Node *primary()
         node = expr();
         expect(")");
     }
-    else if (token->kind == TK_IDENT)
+    else if (token->kind == TK_NUMBER)
     {
-        node = ident();
+        node = num();
     }
     else
     {
-        node = num();
+        node = ident();
     }
     if (consume("["))
     {

--- a/read_token.c
+++ b/read_token.c
@@ -27,32 +27,24 @@ bool consume_rw(TokenKind tk)
 
 Type *consume_type()
 {
-    if (istype(token, INT) || istype(token, CHAR))
+    Type *ty;
+    if (consume_rw(TK_INT))
     {
-        Type *ty;
-        if (istype(token, INT))
-        {
-            ty = new_type_int();
-        }
-        else if (istype(token, CHAR))
-        {
-            ty = new_type_char();
-        }
-        else
-        {
-            error("定義されていない型です");
-        }
-        token = token->next;
-        while (consume("*"))
-        {
-            ty = new_type_ptr(ty);
-        }
-        return ty;
+        ty = new_type_int();
+    }
+    else if (consume_rw(TK_CHAR))
+    {
+        ty = new_type_char();
     }
     else
     {
         return NULL;
     }
+    while (consume("*"))
+    {
+        ty = new_type_ptr(ty);
+    }
+    return ty;
 }
 
 void expect(char *op)
@@ -87,16 +79,4 @@ Token *consume_ident()
 bool at_eof()
 {
     return token->kind == TK_EOF;
-}
-
-static char *types[2] = {
-    "int",
-    "char",
-};
-
-bool istype(Token *tok, TypeKind ty)
-{
-    char *ref = types[ty];
-    int reflen = strlen(ref);
-    return tok->length == reflen && strncmp(tok->string, ref, reflen) == 0;
 }

--- a/read_token.c
+++ b/read_token.c
@@ -25,6 +25,36 @@ bool consume_rw(TokenKind tk)
     return true;
 }
 
+Type *consume_type()
+{
+    if (istype(token, INT) || istype(token, CHAR))
+    {
+        Type *ty;
+        if (istype(token, INT))
+        {
+            ty = new_type_int();
+        }
+        else if (istype(token, CHAR))
+        {
+            ty = new_type_char();
+        }
+        else
+        {
+            error("定義されていない型です");
+        }
+        token = token->next;
+        while (consume("*"))
+        {
+            ty = new_type_ptr(ty);
+        }
+        return ty;
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
 void expect(char *op)
 {
     if (token->kind != TK_OPERATOR || token->string[0] != op[0])

--- a/test/incorrect.c
+++ b/test/incorrect.c
@@ -1,0 +1,4 @@
+int main()
+{
+    return int a = 0;
+}

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -27,13 +27,15 @@ static char *operator_list[20] = {
 
 static int operator_list_count = sizeof(operator_list) / sizeof(operator_list[0]);
 
-static char *reserved_word_list[6] = {
+static char *reserved_word_list[8] = {
     "return",
     "if",
     "else",
     "for",
     "while",
     "sizeof",
+    "int",
+    "char",
 };
 
 static int reserved_word_list_count = sizeof(reserved_word_list) / sizeof(reserved_word_list[0]);


### PR DESCRIPTION
#69 を解消するための下準備
is_typeをconsume_typeで置き換えた
副作用で関数定義、グローバル変数定義でcharが使えるようになったかも？

incorrect.cが通らないようにしたい