### PR TITLE
Arrayの初期化式をサポート

### DIFF
--- a/generator.c
+++ b/generator.c
@@ -208,6 +208,27 @@ static void gen_function_def(Node *node)
     printf("  ret\n");
 }
 
+void gen_assign(Node *node)
+{
+    if (node->kind != ND_ASSIGN)
+    {
+        error("代入式ではありません");
+    }
+    gen_var(node->lhs);
+    gen(node->rhs);
+    printf("  pop rdi\n");
+    printf("  pop rax\n");
+    if (is_int(node->ty))
+        printf("  mov [rax], edi\n");
+    else if (is_char(node->ty))
+    {
+        printf("  mov [rax], dil\n");
+    }
+    else
+        printf("  mov [rax], rdi\n");
+    printf("  push rdi\n");
+}
+
 void gen(Node *node)
 {
     switch (node->kind)
@@ -233,19 +254,7 @@ void gen(Node *node)
         printf("  push rax\n");
         return;
     case ND_ASSIGN:
-        gen_var(node->lhs);
-        gen(node->rhs);
-        printf("  pop rdi\n");
-        printf("  pop rax\n");
-        if (is_int(node->ty))
-            printf("  mov [rax], edi\n");
-        else if (is_char(node->ty))
-        {
-            printf("  mov [rax], dil\n");
-        }
-        else
-            printf("  mov [rax], rdi\n");
-        printf("  push rdi\n");
+        gen_assign(node);
         return;
     case ND_RETURN:
         gen(node->lhs);

--- a/generator.c
+++ b/generator.c
@@ -214,6 +214,34 @@ void gen_assign(Node *node)
     {
         error("代入式ではありません");
     }
+    if (node->rhs && node->rhs->kind == ND_INIT)
+    {
+        if (is_int_or_char(node->lhs->ty))
+        {
+            error("ポインタ型が必要です");
+        }
+        Node *cur = node->rhs;
+        int counter = 0;
+        while (cur)
+        {
+            gen_var(node->lhs);
+            gen(cur->lhs);
+            printf("  pop rdi\n");
+            printf("  pop rax\n");
+            printf("  add rax, %d\n", calc_bytes(node->lhs->ty->ptr_to) * counter);
+            if (is_int(cur->ty))
+                printf("  mov [rax], edi\n");
+            else if (is_char(cur->ty))
+            {
+                printf("  mov [rax], dil\n");
+            }
+            else
+                printf("  mov [rax], rdi\n");
+            cur = cur->rhs;
+            counter++;
+        }
+        return;
+    }
     gen_var(node->lhs);
     gen(node->rhs);
     printf("  pop rdi\n");

--- a/hooligan.h
+++ b/hooligan.h
@@ -58,6 +58,7 @@ typedef enum
     ND_DEREF,
     ND_GVARDEF,
     ND_STRING,
+    ND_INIT,
 } NodeKind;
 
 typedef enum

--- a/hooligan.h
+++ b/hooligan.h
@@ -163,7 +163,7 @@ void gen(Node *node);
 
 // variable.c
 Var *find_var(Token *tok, bool is_local);
-int def_var(Token *tok, Type *ty, bool is_local);
+Var *def_var(Token *tok, Type *ty, bool is_local);
 
 // type.c
 Type *new_type_int();

--- a/parser.c
+++ b/parser.c
@@ -324,14 +324,9 @@ static Node *defl()
             int size = expect_number();
             ty = new_type_array(ty, size);
             expect("]");
-            Var *lvar = def_var(ident, ty, true);
-            return new_node_var(lvar);
         }
-        else
-        {
-            Var *lvar = def_var(ident, ty, true);
-            return new_node_var(lvar);
-        }
+        Var *lvar = def_var(ident, ty, true);
+        return new_node_var(lvar);
     }
     else
     {

--- a/parser.c
+++ b/parser.c
@@ -311,7 +311,18 @@ static Node *assign()
 static Node *init()
 {
     if (consume("{"))
-        error("not implemented");
+    {
+        Node *node = new_node_single(ND_INIT, expr());
+        Node *init_top = node;
+        while (!consume("}"))
+        {
+            expect(",");
+            Node *init = new_node_single(ND_INIT, expr());
+            init_top->rhs = init;
+            init_top = init;
+        }
+        return node;
+    }
     return assign();
 }
 

--- a/parser.c
+++ b/parser.c
@@ -132,10 +132,9 @@ static Node *ident()
     }
     else
     {
-        int offset;
         Var *lvar = find_var(ident, true);
         if (lvar)
-            offset = lvar->offset;
+            return new_node_var(lvar->offset, lvar->ty);
         else
         {
             Var *gvar = find_var(ident, false);
@@ -144,7 +143,6 @@ static Node *ident()
             else
                 error("変数が定義されていません");
         }
-        return new_node_var(offset, lvar->ty);
     }
 }
 

--- a/parser.c
+++ b/parser.c
@@ -326,7 +326,12 @@ static Node *defl()
             expect("]");
         }
         Var *lvar = def_var(ident, ty, true);
-        return new_node_var(lvar);
+        Node *node = new_node_var(lvar);
+        if (consume("="))
+        {
+            node = new_node_assign(node, assign());
+        }
+        return node;
     }
     else
     {
@@ -426,10 +431,6 @@ static Node *stmt()
     else
     {
         node = defl();
-        if (consume("="))
-        {
-            node = new_node_assign(node, assign());
-        }
         expect(";");
     }
     return node;

--- a/parser.c
+++ b/parser.c
@@ -381,7 +381,7 @@ static Node *stmt()
         }
         else
         {
-            init = expr();
+            init = defl();
             expect(";");
         }
 

--- a/parser.c
+++ b/parser.c
@@ -113,24 +113,7 @@ static Node *num()
 
 static Node *ident()
 {
-    Type *ty = consume_type();
     Token *ident = consume_ident();
-    if (ty)
-    {
-        if (consume("["))
-        {
-            int size = expect_number();
-            ty = new_type_array(ty, size);
-            expect("]");
-            int offset = def_var(ident, ty, true);
-            return new_node_var(offset, ty);
-        }
-        else
-        {
-            int offset = def_var(ident, ty, true);
-            return new_node_var(offset, ty);
-        }
-    }
     if (consume("("))
     {
         Node *node = new_node_func(ident->string, ident->length);
@@ -161,7 +144,6 @@ static Node *ident()
             else
                 error("変数が定義されていません");
         }
-
         return new_node_var(offset, lvar->ty);
     }
 }
@@ -333,6 +315,32 @@ static Node *expr()
     return assign();
 }
 
+static Node *defl()
+{
+    Type *ty = consume_type();
+    if (ty)
+    {
+        Token *ident = consume_ident();
+        if (consume("["))
+        {
+            int size = expect_number();
+            ty = new_type_array(ty, size);
+            expect("]");
+            int offset = def_var(ident, ty, true);
+            return new_node_var(offset, ty);
+        }
+        else
+        {
+            int offset = def_var(ident, ty, true);
+            return new_node_var(offset, ty);
+        }
+    }
+    else
+    {
+        return expr();
+    }
+}
+
 static Node *stmt()
 {
     Node *node;
@@ -424,7 +432,11 @@ static Node *stmt()
     }
     else
     {
-        node = expr();
+        node = defl();
+        if (consume("="))
+        {
+            node = new_node_assign(node, assign());
+        }
         expect(";");
     }
     return node;

--- a/parser.c
+++ b/parser.c
@@ -308,6 +308,13 @@ static Node *assign()
     return node;
 }
 
+static Node *init()
+{
+    if (consume("{"))
+        error("not implemented");
+    return assign();
+}
+
 static Node *expr()
 {
     return assign();
@@ -329,7 +336,7 @@ static Node *defl()
         Node *node = new_node_var(lvar);
         if (consume("="))
         {
-            node = new_node_assign(node, assign());
+            node = new_node_assign(node, init());
         }
         return node;
     }

--- a/parser.c
+++ b/parser.c
@@ -68,12 +68,12 @@ static Node *new_node_num(int val)
     return node;
 }
 
-static Node *new_node_var(int offset, Type *ty)
+static Node *new_node_var(Var *lvar)
 {
     Node *node = calloc(1, sizeof(Node));
     node->kind = ND_VAR;
-    node->offset = offset;
-    node->ty = ty;
+    node->offset = lvar->offset;
+    node->ty = lvar->ty;
     node->is_local = true;
     return node;
 }
@@ -134,7 +134,7 @@ static Node *ident()
     {
         Var *lvar = find_var(ident, true);
         if (lvar)
-            return new_node_var(lvar->offset, lvar->ty);
+            return new_node_var(lvar);
         else
         {
             Var *gvar = find_var(ident, false);
@@ -324,13 +324,13 @@ static Node *defl()
             int size = expect_number();
             ty = new_type_array(ty, size);
             expect("]");
-            int offset = def_var(ident, ty, true);
-            return new_node_var(offset, ty);
+            Var *lvar = def_var(ident, ty, true);
+            return new_node_var(lvar);
         }
         else
         {
-            int offset = def_var(ident, ty, true);
-            return new_node_var(offset, ty);
+            Var *lvar = def_var(ident, ty, true);
+            return new_node_var(lvar);
         }
     }
     else
@@ -459,8 +459,8 @@ static Node *func(Token *ident, Type *ty)
         if (!arg_ty)
             error("引数に型がありません");
         Token *arg_token = consume_ident();
-        int offset = def_var(arg_token, arg_ty, true);
-        Node *arg = new_node_var(offset, arg_ty);
+        Var *lvar = def_var(arg_token, arg_ty, true);
+        Node *arg = new_node_var(lvar);
         arg_top->lhs = arg;
         arg_top = arg;
     }

--- a/test/ctrl.c
+++ b/test/ctrl.c
@@ -3,8 +3,7 @@ int main()
     int a;
 
     a = 0;
-    int counter;
-    for (counter = 0; counter < 100; counter = counter + 1)
+    for (int counter = 0; counter < 100; counter = counter + 1)
         if (counter * counter == 400)
             a = counter;
     if (a != 20)

--- a/test/incorrect.c
+++ b/test/incorrect.c
@@ -1,4 +1,0 @@
-int main()
-{
-    return int a = 0;
-}

--- a/test/init_expr.c
+++ b/test/init_expr.c
@@ -1,0 +1,17 @@
+int main()
+{
+    int x[3] = {1, 2, 3};
+    if (x[0] != 1)
+    {
+        return 1;
+    }
+    if (x[1] != 2)
+    {
+        return 1;
+    }
+    if (x[2] != 3)
+    {
+        return 1;
+    }
+    return 0;
+}

--- a/variable.c
+++ b/variable.c
@@ -34,7 +34,7 @@ Var *find_var(Token *tok, bool is_local)
         return find_gvar(tok);
 }
 
-static int def_lvar(Token *tok, Type *ty)
+static Var *def_lvar(Token *tok, Type *ty)
 {
     int offset;
     Var *new_lvar = calloc(1, sizeof(Var));
@@ -56,10 +56,10 @@ static int def_lvar(Token *tok, Type *ty)
     new_lvar->offset = offset;
     new_lvar->next = locals;
     locals = new_lvar;
-    return offset;
+    return new_lvar;
 }
 
-static int def_gvar(Token *tok, Type *ty)
+static Var *def_gvar(Token *tok, Type *ty)
 {
     Var *new_gvar = calloc(1, sizeof(Var));
     new_gvar->name = tok->string;
@@ -67,15 +67,13 @@ static int def_gvar(Token *tok, Type *ty)
     new_gvar->ty = ty;
     new_gvar->next = globals;
     globals = new_gvar;
-    return 0;
+    return new_gvar;
 }
 
-int def_var(Token *tok, Type *ty, bool is_local)
+Var *def_var(Token *tok, Type *ty, bool is_local)
 {
     if (is_local)
         return def_lvar(tok, ty);
     else
         return def_gvar(tok, ty);
 }
-
-


### PR DESCRIPTION
- #69 の対応を含む


以下のような特殊なパターンは未対応

- `int x[5] = {1, 2, 3};`
- `int x[] = {0, 1, 2};`