### PR TITLE
関数定義をグローバル変数に格納する

### DIFF
--- a/generator.c
+++ b/generator.c
@@ -565,7 +565,7 @@ void gen(Node *node)
 }
 
 String *strings;
-StaticVar *statics;
+Var *statics;
 int label = 0; // なんのラベルかわからん
 Node *nodes[200];
 Node *funcs[100];
@@ -590,7 +590,7 @@ void gen_asm_intel()
         i++;
     }
     String *s = strings;
-    StaticVar *sv = statics;
+    Var *sv = statics;
     while (sv)
     {
         println("L%.*s.%d:", sv->length, sv->name, sv->label);

--- a/generator.c
+++ b/generator.c
@@ -437,7 +437,7 @@ void gen(Node *node)
     case ND_POSTINC:
         gen(node->lhs); // インクリメント前の値がpushされる
         gen(node->rhs); // インクリメント後の値がpushされる
-        pop(RG_RAX); // インクリメント後の値がpopされる
+        pop(RG_RAX);    // インクリメント後の値がpopされる
         // スタックトップはインクリメント前の値
         return;
     case ND_ADD:
@@ -561,11 +561,9 @@ void gen(Node *node)
     }
 }
 
-Node *nodes[200];
-Node *funcs[100];
-
 void gen_asm_intel()
 {
+    Node *funcs[100];
     println(".intel_syntax noprefix");
     println(".data");
     program();

--- a/generator.c
+++ b/generator.c
@@ -561,8 +561,6 @@ void gen(Node *node)
     }
 }
 
-String *strings;
-Var *statics;
 Node *nodes[200];
 Node *funcs[100];
 
@@ -585,8 +583,8 @@ void gen_asm_intel()
         gen(nodes[i]);
         i++;
     }
-    String *s = strings;
-    Var *sv = statics;
+    String *s = ctx->strings;
+    Var *sv = ctx->statics;
     while (sv)
     {
         println("L%.*s.%d:", sv->length, sv->name, sv->label);

--- a/generator.c
+++ b/generator.c
@@ -367,11 +367,9 @@ void gen(Node *node)
         println("  ret");
         return;
     case ND_IF:
-        label++;
         gen_if(node);
         return;
     case ND_FOR:
-        label++;
         gen_for(node);
         return;
     case ND_BLOCK:
@@ -383,7 +381,6 @@ void gen(Node *node)
         gen(node->rhs);
         return;
     case ND_WHILE:
-        label++;
         gen_while(node);
         return;
     case ND_BREAK:
@@ -566,7 +563,6 @@ void gen(Node *node)
 
 String *strings;
 Var *statics;
-int label = 0; // なんのラベルかわからん
 Node *nodes[200];
 Node *funcs[100];
 

--- a/hooligan.h
+++ b/hooligan.h
@@ -258,6 +258,7 @@ void gen_asm_intel();
 Var *find_var(Token *tok);
 Var *def_var(Token *tok, Type *ty, bool is_local);
 Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val);
+Var *find_func(Token *tok);
 Var *def_func(Token *tok, Type *ty, bool is_static);
 
 // type.c

--- a/hooligan.h
+++ b/hooligan.h
@@ -186,6 +186,8 @@ struct Var
     // for static variable
     bool is_static;
     int init_val;
+    // for function
+    bool is_function;
 };
 
 struct String
@@ -221,6 +223,7 @@ struct Context{
     Scope *scope;
     String *strings;
     Var *statics;
+    Var *functions;
     int offset; // for local variable
     int break_to;
     int continue_to;
@@ -255,6 +258,8 @@ void gen_asm_intel();
 Var *find_var(Token *tok);
 Var *def_var(Token *tok, Type *ty, bool is_local);
 Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val);
+Var *def_func(Token *tok, Type *ty, bool is_static);
+
 // type.c
 Type *new_type_int();
 Type *new_type_char();

--- a/hooligan.h
+++ b/hooligan.h
@@ -101,7 +101,6 @@ typedef struct Type Type;
 typedef struct Node Node;
 typedef struct Var Var;
 typedef struct String String;
-typedef struct StaticVar StaticVar;
 typedef struct Member Member;
 typedef struct Scope Scope;
 
@@ -183,7 +182,9 @@ struct Var
     Var *next;
     bool is_local;
     bool is_typedef;
+    // for static variable
     bool is_static;
+    int init_val;
 };
 
 struct String
@@ -194,15 +195,6 @@ struct String
     String *next;
 };
 
-struct StaticVar
-{
-    char *name;
-    int length;
-    Type *ty;
-    int label;
-    int init_val;
-    StaticVar *next;
-};
 struct Member
 {
 
@@ -229,7 +221,7 @@ extern int offset;
 extern Token *token;
 extern Node *nodes[200];
 extern String *strings;
-extern StaticVar *statics;
+extern Var *statics;
 extern Scope *current_scope;
 
 // Declaration of functions

--- a/hooligan.h
+++ b/hooligan.h
@@ -221,10 +221,10 @@ struct Context{
     Scope *scope;
     String *strings;
     Var *statics;
+    int offset; // for local variable
 };
 
 // Declaration of global variables
-extern int offset;
 extern Token *token;
 extern Node *nodes[200];
 extern Context *ctx;

--- a/hooligan.h
+++ b/hooligan.h
@@ -103,6 +103,7 @@ typedef struct Var Var;
 typedef struct String String;
 typedef struct Member Member;
 typedef struct Scope Scope;
+typedef struct Context Context;
 
 struct Token
 {
@@ -215,14 +216,17 @@ struct Scope
     int loop_label; // for break and continue
 };
 
+struct Context{
+    Scope *scope;
+    String *strings;
+    Var *statics;
+};
+
 // Declaration of global variables
-extern int label;
 extern int offset;
 extern Token *token;
 extern Node *nodes[200];
-extern String *strings;
-extern Var *statics;
-extern Scope *current_scope;
+extern Context *ctx;
 
 // Declaration of functions
 // read_token.c

--- a/hooligan.h
+++ b/hooligan.h
@@ -247,7 +247,7 @@ void gen_asm_intel();
 // variable.c
 Var *find_var(Token *tok);
 Var *def_var(Token *tok, Type *ty, bool is_local);
-Var *def_var_static(Token *tok, Type *ty, bool is_local);
+Var *def_var_static(Token *tok, Type *ty, bool is_local, int init_val);
 // type.c
 Type *new_type_int();
 Type *new_type_char();

--- a/hooligan.h
+++ b/hooligan.h
@@ -222,6 +222,8 @@ struct Context{
     String *strings;
     Var *statics;
     int offset; // for local variable
+    int break_to;
+    int continue_to;
 };
 
 // Declaration of global variables

--- a/hooligan.h
+++ b/hooligan.h
@@ -217,6 +217,7 @@ struct Scope
 };
 
 struct Context{
+    int scope_serial_num; // serial number for scope
     Scope *scope;
     String *strings;
     Var *statics;

--- a/hooligan.h
+++ b/hooligan.h
@@ -247,7 +247,7 @@ void gen_asm_intel();
 // variable.c
 Var *find_var(Token *tok);
 Var *def_var(Token *tok, Type *ty, bool is_local);
-Var *def_var_static(Token *tok, Type *ty, bool is_local, int init_val);
+Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val);
 // type.c
 Type *new_type_int();
 Type *new_type_char();

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include "hooligan.h"
 
 Token *token;
+Node *nodes[200];
 Context *ctx;
 
 // 指定されたファイルの内容を返す

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include "hooligan.h"
 
 Token *token;
+Context *ctx;
 
 // 指定されたファイルの内容を返す
 static char *read_file(char *path)

--- a/parser.c
+++ b/parser.c
@@ -21,13 +21,15 @@ static String *new_string(char *p, int length)
 
 static void new_static_var(char *name, int length, Type *ty, int label, int init_val)
 {
-    StaticVar *new_static = calloc(1, sizeof(StaticVar));
+    Var *new_static = calloc(1, sizeof(Var));
     new_static->length = length;
     new_static->name = name;
     new_static->ty = ty;
     new_static->next = statics;
     new_static->label = label;
     new_static->init_val = init_val;
+    new_static->is_static = true;
+    new_static->is_local = true;
     statics = new_static;
     return;
 }

--- a/parser.c
+++ b/parser.c
@@ -756,7 +756,7 @@ static Node *func(Token *ident, Type *ty)
         arg_top = arg;
     }
     node->rhs = block();
-    node->args_region_size = offset;
+    node->args_region_size = ctx->offset;
     exit_scope();
     return node;
 }
@@ -822,7 +822,7 @@ void program()
         Node *node = def();
         nodes[i] = node;
         i++;
-        offset = 0;
+        ctx->offset = 0;
     }
     nodes[i + 1] = NULL;
 }

--- a/parser.c
+++ b/parser.c
@@ -688,13 +688,13 @@ static Node *stmt()
     {
         node = calloc(1, sizeof(Node));
         node->kind = ND_BREAK;
-        node->loop_label = ctx->scope->loop_label;
+        node->loop_label = ctx->break_to;
     }
     else if (consume_rw(TK_CONTINUE))
     {
         node = calloc(1, sizeof(Node));
         node->kind = ND_CONTINUE;
-        node->loop_label = ctx->scope->loop_label;
+        node->loop_label = ctx->continue_to;
     }
     else
     {

--- a/parser.c
+++ b/parser.c
@@ -19,21 +19,6 @@ static String *new_string(char *p, int length)
     return new_string;
 }
 
-static void new_static_var(char *name, int length, Type *ty, int label, int init_val)
-{
-    Var *new_static = calloc(1, sizeof(Var));
-    new_static->length = length;
-    new_static->name = name;
-    new_static->ty = ty;
-    new_static->next = statics;
-    new_static->label = label;
-    new_static->init_val = init_val;
-    new_static->is_static = true;
-    new_static->is_local = true;
-    statics = new_static;
-    return;
-}
-
 static Node *unary();
 static Node *expr();
 static Node *block();
@@ -494,13 +479,12 @@ static Node *defl()
             ty = new_type_array(ty, size);
             expect("]");
         }
-        Var *svar = def_var_static(ident, ty, true);
         int val = 0;
         if (consume("="))
         {
             val = expect_number();
         }
-        new_static_var(ident->string, ident->length, ty, svar->label, val);
+        Var *svar = def_var_static(ident, ty, true, val);
         return new_node_nop();
     }
     else

--- a/parser.c
+++ b/parser.c
@@ -484,7 +484,7 @@ static Node *defl()
         {
             val = expect_number();
         }
-        Var *svar = def_var_static(ident, ty, true, val);
+        Var *svar = def_static_var(ident, ty, true, val);
         return new_node_nop();
     }
     else

--- a/parser.c
+++ b/parser.c
@@ -5,17 +5,17 @@ static String *new_string(char *p, int length)
     String *new_string = calloc(1, sizeof(String));
     new_string->length = length;
     new_string->p = p;
-    if (strings)
+    if (ctx->strings)
     {
-        strlabel = strings->label + 1;
+        strlabel = ctx->strings->label + 1;
     }
     else
     {
         strlabel = 0;
     }
     new_string->label = strlabel;
-    new_string->next = strings;
-    strings = new_string;
+    new_string->next = ctx->strings;
+    ctx->strings = new_string;
     return new_string;
 }
 
@@ -621,7 +621,7 @@ static Node *stmt()
         node->body = iftrue;
         if (consume_rw(TK_ELSE))
             node->on_else = block();
-        node->cond_label = current_scope->label;
+        node->cond_label = ctx->scope->label;
         exit_scope();
     }
     else if (consume_rw(TK_FOR))
@@ -667,7 +667,7 @@ static Node *stmt()
         node->condition = condition;
         node->on_end = on_end;
         node->body = body;
-        node->loop_label = current_scope->loop_label;
+        node->loop_label = ctx->scope->loop_label;
         end_loop();
     }
     else if (consume_rw(TK_WHILE))
@@ -681,20 +681,20 @@ static Node *stmt()
         node->kind = ND_WHILE;
         node->condition = condition;
         node->body = body;
-        node->loop_label = current_scope->loop_label;
+        node->loop_label = ctx->scope->loop_label;
         end_loop();
     }
     else if (consume_rw(TK_BREAK))
     {
         node = calloc(1, sizeof(Node));
         node->kind = ND_BREAK;
-        node->loop_label = current_scope->loop_label;
+        node->loop_label = ctx->scope->loop_label;
     }
     else if (consume_rw(TK_CONTINUE))
     {
         node = calloc(1, sizeof(Node));
         node->kind = ND_CONTINUE;
-        node->loop_label = current_scope->loop_label;
+        node->loop_label = ctx->scope->loop_label;
     }
     else
     {
@@ -814,7 +814,8 @@ static Node *def()
 
 void program()
 {
-    current_scope = calloc(1, sizeof(Scope));
+    ctx = calloc(1, sizeof(Context));
+    ctx->scope = calloc(1, sizeof(Scope));
     int i = 0;
     while (!at_eof())
     {

--- a/parser.c
+++ b/parser.c
@@ -730,7 +730,7 @@ static Node *block()
     return stmt();
 }
 
-static Node *func(Token *ident, Type *ty)
+static Node *func(Token *ident, Type *ty, bool is_static)
 {
     new_scope();
     Node *node = calloc(1, sizeof(Node));
@@ -757,6 +757,7 @@ static Node *func(Token *ident, Type *ty)
     }
     node->rhs = block();
     node->args_region_size = ctx->offset;
+    def_func(ident, ty, is_static);
     exit_scope();
     return node;
 }
@@ -783,6 +784,7 @@ static Node *def()
         return node;
     }
     bool is_extern = consume_rw(TK_EXTERN);
+    bool is_static = consume_rw(is_static);
     Type *ty = consume_type();
     if (!ty)
     {
@@ -791,7 +793,7 @@ static Node *def()
     Token *ident = consume_ident();
     if (consume("("))
     {
-        node = func(ident, ty);
+        node = func(ident, ty, is_static);
     }
     else
     {

--- a/parser.c
+++ b/parser.c
@@ -122,10 +122,19 @@ static Node *ident()
     {
         Node *node = calloc(1, sizeof(Node));
         node->kind = ND_FUNC;
-        node->name = ident->string;
-        node->length = ident->length;
-        node->ty = new_type_int(); // TODO 関数の戻り値をどこかに保存しなければならない
-
+        Var *func = find_func(ident);
+        if (func)
+        {
+            node->name = func->name;
+            node->length = func->length;
+            node->ty = func->ty;
+        }
+        else
+        {
+            node->name = ident->string;
+            node->length = ident->length;
+            node->ty = new_type_int();
+        }
         Node *arg_top = node;
         int count = 0;
         while (!consume(")"))

--- a/scope.c
+++ b/scope.c
@@ -1,13 +1,11 @@
 #include "hooligan.h"
 
-int scope_label = 1;
-
 void new_scope()
 {
     Scope *scope = calloc(1, sizeof(Node));
     scope->prev = ctx->scope;
-    scope_label++;
-    scope->label = scope_label;
+    ctx->scope_serial_num++;
+    scope->label = ctx->scope_serial_num;
     scope->loop_label = ctx->scope->loop_label;
     ctx->scope->next = scope;
     ctx->scope = scope;

--- a/scope.c
+++ b/scope.c
@@ -20,9 +20,13 @@ void start_loop()
 {
     new_scope();
     ctx->scope->loop_label = ctx->scope->label;
+    ctx->break_to = ctx->scope->loop_label;
+    ctx->continue_to = ctx->scope->loop_label;
 }
 
 void end_loop()
 {
     exit_scope();
+    ctx->break_to = ctx->scope->loop_label;
+    ctx->continue_to = ctx->scope->loop_label;
 }

--- a/scope.c
+++ b/scope.c
@@ -1,28 +1,27 @@
 #include "hooligan.h"
 
-Scope *current_scope;
 int scope_label = 1;
 
 void new_scope()
 {
     Scope *scope = calloc(1, sizeof(Node));
-    scope->prev = current_scope;
+    scope->prev = ctx->scope;
     scope_label++;
     scope->label = scope_label;
-    scope->loop_label = current_scope->loop_label;
-    current_scope->next = scope;
-    current_scope = scope;
+    scope->loop_label = ctx->scope->loop_label;
+    ctx->scope->next = scope;
+    ctx->scope = scope;
 }
 
 void exit_scope()
 {
-    current_scope = current_scope->prev;
+    ctx->scope = ctx->scope->prev;
 }
 
 void start_loop()
 {
     new_scope();
-    current_scope->loop_label = current_scope->label;
+    ctx->scope->loop_label = ctx->scope->label;
 }
 
 void end_loop()

--- a/test/func.c
+++ b/test/func.c
@@ -29,6 +29,10 @@ int testFuncPtr()
     {
         return 1;
     }
+    if (*(bar(&a)) != 11)
+    {
+        return 1;
+    }
     g[0] = 1;
     g[1] = 2;
     g[2] = 3;

--- a/type.c
+++ b/type.c
@@ -113,7 +113,7 @@ Type *determine_expr_type(Type *lhs, Type *rhs)
 
 Type *find_type(Token *tok)
 {
-    for (Scope *scope = current_scope; scope; scope = scope->prev)
+    for (Scope *scope = ctx->scope; scope; scope = scope->prev)
     {
         for (Type *type = scope->types; type; type = type->next)
         {
@@ -136,7 +136,7 @@ Type *def_type(Token *tok, Type *ty, bool is_local)
     new_type->array_size = ty->array_size;
     new_type->members = ty->members;
     new_type->size = ty->size;
-    new_type->next = current_scope->types;
-    current_scope->types = new_type;
+    new_type->next = ctx->scope->types;
+    ctx->scope->types = new_type;
     return new_type;
 }

--- a/variable.c
+++ b/variable.c
@@ -53,3 +53,16 @@ Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val)
     ctx->statics = new_static;
     return new_var;
 }
+
+Var *def_func(Token *tok, Type *ty, bool is_static)
+{
+    Var *new_func = calloc(1, sizeof(Var));
+    new_func->length = tok->length;
+    new_func->name = tok->string;
+    new_func->ty = ty;
+    new_func->next = ctx->functions;
+    new_func->label = ctx->scope->label;
+    new_func->is_static = is_static;
+    ctx->functions = new_func;
+    return new_func;
+}

--- a/variable.c
+++ b/variable.c
@@ -37,10 +37,21 @@ Var *def_var(Token *tok, Type *ty, bool is_local)
     return new_var;
 }
 
-Var *def_var_static(Token *tok, Type *ty, bool is_local)
+Var *def_var_static(Token *tok, Type *ty, bool is_local, int init_val)
 {
     Var *new_var = def_var(tok, ty, is_local);
     new_var->is_static = true;
     new_var->label = current_scope->label;
+    // nextメンバが上書きされてしまうので二回Varを生成している
+    Var *new_static = calloc(1, sizeof(Var));
+    new_static->length = tok->length;
+    new_static->name = tok->string;
+    new_static->ty = ty;
+    new_static->next = statics;
+    new_static->label = current_scope->label;
+    new_static->init_val = init_val;
+    new_static->is_static = true;
+    new_static->is_local = true;
+    statics = new_static;
     return new_var;
 }

--- a/variable.c
+++ b/variable.c
@@ -37,7 +37,7 @@ Var *def_var(Token *tok, Type *ty, bool is_local)
     return new_var;
 }
 
-Var *def_var_static(Token *tok, Type *ty, bool is_local, int init_val)
+Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val)
 {
     Var *new_var = def_var(tok, ty, is_local);
     new_var->is_static = true;

--- a/variable.c
+++ b/variable.c
@@ -54,6 +54,18 @@ Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val)
     return new_var;
 }
 
+Var *find_func(Token *tok)
+{
+    for (Var *func = ctx->functions; func; func = func->next)
+    {
+        if (func->length == tok->length && memcmp(func->name, tok->string, func->length) == 0)
+        {
+            return func;
+        }
+    }
+    return NULL;
+}
+
 Var *def_func(Token *tok, Type *ty, bool is_static)
 {
     Var *new_func = calloc(1, sizeof(Var));

--- a/variable.c
+++ b/variable.c
@@ -1,7 +1,5 @@
 #include "hooligan.h"
 
-int offset;
-
 Var *find_var(Token *tok)
 {
     for (Scope *scope = ctx->scope; scope; scope = scope->prev)
@@ -27,8 +25,8 @@ Var *def_var(Token *tok, Type *ty, bool is_local)
     if (is_local)
     {
         int var_size = calc_bytes(ty);
-        offset += var_size;
-        new_var->offset = offset;
+        ctx->offset += var_size;
+        new_var->offset = ctx->offset;
     }
     new_var->next = ctx->scope->variables;
     ctx->scope->variables = new_var;

--- a/variable.c
+++ b/variable.c
@@ -4,7 +4,7 @@ int offset;
 
 Var *find_var(Token *tok)
 {
-    for (Scope *scope = current_scope; scope; scope = scope->prev)
+    for (Scope *scope = ctx->scope; scope; scope = scope->prev)
     {
         for (Var *var = scope->variables; var; var = var->next)
         {
@@ -30,8 +30,8 @@ Var *def_var(Token *tok, Type *ty, bool is_local)
         offset += var_size;
         new_var->offset = offset;
     }
-    new_var->next = current_scope->variables;
-    current_scope->variables = new_var;
+    new_var->next = ctx->scope->variables;
+    ctx->scope->variables = new_var;
     new_var->is_local = is_local;
     new_var->is_static = false;
     return new_var;
@@ -41,17 +41,17 @@ Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val)
 {
     Var *new_var = def_var(tok, ty, is_local);
     new_var->is_static = true;
-    new_var->label = current_scope->label;
+    new_var->label = ctx->scope->label;
     // nextメンバが上書きされてしまうので二回Varを生成している
     Var *new_static = calloc(1, sizeof(Var));
     new_static->length = tok->length;
     new_static->name = tok->string;
     new_static->ty = ty;
-    new_static->next = statics;
-    new_static->label = current_scope->label;
+    new_static->next = ctx->statics;
+    new_static->label = ctx->scope->label;
     new_static->init_val = init_val;
     new_static->is_static = true;
     new_static->is_local = true;
-    statics = new_static;
+    ctx->statics = new_static;
     return new_var;
 }


### PR DESCRIPTION
void型実装の下準備（#87）

- グローバル変数をstruct Contextに集約（リファクタリング）
- 関数が定義されたときに名前と返り値の情報を格納しておく（引数は格納していない、さぼった）
- 関数呼び出しの際には定義済みの関数を探し、見つかれば返り値の情報等を取り出す