### PR TITLE
関数定義時に引数を保存

### DIFF
--- a/hooligan.h
+++ b/hooligan.h
@@ -164,6 +164,9 @@ struct Node
     // for function
     int args_region_size;
     Node *args;
+    int num_args;
+    Type *arg_ty_ls[6];
+    bool is_void;
 
     // for string
     int strlabel;

--- a/hooligan.h
+++ b/hooligan.h
@@ -189,6 +189,8 @@ struct Var
     int init_val;
     // for function
     bool is_function;
+    int num_args;
+    Type *arg_ty_ls[6];
 };
 
 struct String
@@ -219,7 +221,8 @@ struct Scope
     int loop_label; // for break and continue
 };
 
-struct Context{
+struct Context
+{
     int scope_serial_num; // serial number for scope
     Scope *scope;
     String *strings;
@@ -260,7 +263,7 @@ Var *find_var(Token *tok);
 Var *def_var(Token *tok, Type *ty, bool is_local);
 Var *def_static_var(Token *tok, Type *ty, bool is_local, int init_val);
 Var *find_func(Token *tok);
-Var *def_func(Token *tok, Type *ty, bool is_static);
+Var *def_func(Token *tok, Type *ty, int num_args, Type *arg_ty_ls[], bool is_static);
 
 // type.c
 Type *new_type_int();

--- a/hooligan.h
+++ b/hooligan.h
@@ -165,7 +165,6 @@ struct Node
     int args_region_size;
     Node *args;
     int num_args;
-    Type *arg_ty_ls[6];
     bool is_void;
 
     // for string

--- a/hooligan.h
+++ b/hooligan.h
@@ -18,6 +18,7 @@ typedef enum
     TK_FOR,
     TK_WHILE,
     TK_SIZEOF,
+    TK_VOID,
     TK_INT,
     TK_CHAR,
     TK_STRUCT,
@@ -75,12 +76,12 @@ typedef enum
 
 typedef enum
 {
+    VOID,
     INT,
     CHAR,
     PTR,
     ARRAY,
     STRUCT,
-
 } TypeKind;
 
 typedef enum
@@ -269,6 +270,8 @@ Var *def_func(Token *tok, Type *ty, int num_args, Type *arg_ty_ls[], bool is_sta
 Type *new_type_int();
 Type *new_type_char();
 Type *new_type_string();
+Type *new_type_void();
+
 Type *new_type_ptr(Type *ptr_to);
 Type *new_type_array(Type *ptr_to, size_t size);
 Type *new_type_struct();

--- a/parser.c
+++ b/parser.c
@@ -760,11 +760,14 @@ static Node *func(Token *ident, Type *ty, bool is_static)
         Type *arg_ty = consume_type();
         if (!arg_ty)
             error("引数に型がありません");
-        Token *arg_token = consume_ident();
-        Var *lvar = def_var(arg_token, arg_ty, true);
-        Node *arg = new_node_var(lvar);
-        arg_top->lhs = arg;
-        arg_top = arg;
+        else if (arg_ty->ty != VOID)
+        {
+            Token *arg_token = consume_ident();
+            Var *lvar = def_var(arg_token, arg_ty, true);
+            Node *arg = new_node_var(lvar);
+            arg_top->lhs = arg;
+            arg_top = arg;
+        }
         arg_ty_ls[arg_idx] = arg_ty;
         arg_idx++;
     }

--- a/parser.c
+++ b/parser.c
@@ -749,13 +749,13 @@ static Node *func(Token *ident, Type *ty, bool is_static)
     node->name = ident->string;
     node->length = ident->length;
     Node *arg_top = node;
-    int arg_count = 0;
+    Type *arg_ty_ls[6];
+    int arg_idx = 0;
     while (!consume(")"))
     {
-        arg_count++;
-        if (arg_count > 6)
+        if (arg_idx >= 6)
             error("引数の数が多すぎます");
-        if (arg_count != 1)
+        if (arg_idx != 0)
             expect(",");
         Type *arg_ty = consume_type();
         if (!arg_ty)
@@ -765,10 +765,12 @@ static Node *func(Token *ident, Type *ty, bool is_static)
         Node *arg = new_node_var(lvar);
         arg_top->lhs = arg;
         arg_top = arg;
+        arg_ty_ls[arg_idx] = arg_ty;
+        arg_idx++;
     }
     node->rhs = block();
     node->args_region_size = ctx->offset;
-    def_func(ident, ty, is_static);
+    def_func(ident, ty, arg_idx, arg_ty_ls, is_static);
     exit_scope();
     return node;
 }

--- a/parser.c
+++ b/parser.c
@@ -163,6 +163,10 @@ static Node *ident()
                     arg_top->next = arg;
                     arg_top = arg;
                 }
+                else
+                {
+                    expr();
+                }
                 count++;
             }
             if (not(node->is_void) && count < node->num_args)

--- a/parser.c
+++ b/parser.c
@@ -187,8 +187,9 @@ static Node *ident()
                 Node *arg = new_node_single(ND_ARG, expr());
                 arg_top->next = arg;
                 arg_top = arg;
+
+                count++;
             }
-            count++;
         }
 
         return node;

--- a/parser.c
+++ b/parser.c
@@ -134,12 +134,7 @@ static Node *ident()
             node->length = func->length;
             node->ty = func->ty;
             node->num_args = func->num_args;
-            for (int i = 0; i < node->num_args; i++)
-            {
-                node->arg_ty_ls[i] = func->arg_ty_ls[i];
-            }
-
-            if (node->num_args != 0 && node->arg_ty_ls[0]->ty == VOID)
+            if (node->num_args != 0 && func->arg_ty_ls[0]->ty == VOID)
             {
                 node->is_void = true;
             }

--- a/read_token.c
+++ b/read_token.c
@@ -36,6 +36,10 @@ Type *consume_type()
     {
         ty = new_type_struct();
     }
+    else if (consume_rw(TK_VOID))
+    {
+        ty = new_type_void();
+    }
     else
     {
         return NULL;

--- a/test/array.c
+++ b/test/array.c
@@ -213,7 +213,18 @@ int testArrayInitString()
     printf(c_over);
     return 0;
 }
-
+int foovoid(void)
+{
+    return 11;
+}
+int testArrayVoid()
+{
+    if (foovoid() != 11)
+    {
+        return 1;
+    }
+    return 0;
+}
 int main()
 {
     if (testArray() != 0)
@@ -247,6 +258,11 @@ int main()
     }
 
     if (testArrayInitString() != 0)
+    {
+        return 1;
+    }
+
+    if (testArrayVoid() != 0)
     {
         return 1;
     }

--- a/test/array.c
+++ b/test/array.c
@@ -213,18 +213,7 @@ int testArrayInitString()
     printf(c_over);
     return 0;
 }
-int foovoid(void)
-{
-    return 11;
-}
-int testArrayVoid()
-{
-    if (foovoid() != 11)
-    {
-        return 1;
-    }
-    return 0;
-}
+
 int main()
 {
     if (testArray() != 0)
@@ -258,11 +247,6 @@ int main()
     }
 
     if (testArrayInitString() != 0)
-    {
-        return 1;
-    }
-
-    if (testArrayVoid() != 0)
     {
         return 1;
     }

--- a/test/func.c
+++ b/test/func.c
@@ -7,6 +7,25 @@ int testFunc()
     }
     return 0;
 }
+int sums(int x, int y)
+{
+    return x + y;
+}
+int testFuncTooMany()
+{
+    int x = 10;
+    int y = 22;
+    if (sums(x, y) != 32)
+    {
+        return 1;
+    }
+
+    if (sums(x, y, y) != 32)
+    {
+        return 1;
+    }
+    return 0;
+}
 int a;
 int g[10];
 
@@ -42,14 +61,34 @@ int testFuncPtr()
     }
     return 0;
 }
-
+int foovoid(void)
+{
+    return 11;
+}
+int testFuncVoid()
+{
+    if (foovoid() != 11)
+    {
+        return 1;
+    }
+    return 0;
+}
 int main()
 {
     if (testFunc() != 0)
     {
         return 1;
     }
+    if (testFuncTooMany() != 0)
+    {
+        return 1;
+    }
+
     if (testFuncPtr() != 0)
+    {
+        return 1;
+    }
+    if (testFuncVoid() != 0)
     {
         return 1;
     }

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -35,13 +35,14 @@ static char *operator_list[28] = {
 
 static int operator_list_count = sizeof(operator_list) / sizeof(operator_list[0]);
 
-static char *reserved_word_list[14] = {
+static char *reserved_word_list[15] = {
     "return",
     "if",
     "else",
     "for",
     "while",
     "sizeof",
+    "void",
     "int",
     "char",
     "struct",
@@ -162,8 +163,9 @@ Token *tokenize(char *p)
             continue;
         }
 
-        if(*p == 39){ // ' バックスラッシュによるエスケープを使いたくなかった
-        
+        if (*p == 39)
+        { // ' バックスラッシュによるエスケープを使いたくなかった
+
             p++;
             cur = new_token(TK_CHARACTER, cur, p);
             cur->length = 1;

--- a/type.c
+++ b/type.c
@@ -66,6 +66,17 @@ Type *new_type_struct()
     return ty;
 }
 
+Type *new_type_void()
+{
+    static Type *ty;
+    if (!ty)
+    {
+        ty = calloc(1, sizeof(Type));
+        ty->ty = VOID;
+    }
+    return ty;
+}
+
 bool is_int(Type *ty)
 {
     return ty->ty == INT;

--- a/variable.c
+++ b/variable.c
@@ -66,7 +66,7 @@ Var *find_func(Token *tok)
     return NULL;
 }
 
-Var *def_func(Token *tok, Type *ty, bool is_static)
+Var *def_func(Token *tok, Type *ty, int num_args, Type *arg_ty_ls[], bool is_static)
 {
     Var *new_func = calloc(1, sizeof(Var));
     new_func->length = tok->length;
@@ -75,6 +75,11 @@ Var *def_func(Token *tok, Type *ty, bool is_static)
     new_func->next = ctx->functions;
     new_func->label = ctx->scope->label;
     new_func->is_static = is_static;
+    new_func->num_args = num_args;
+    for (int i = 0; i < num_args; i++)
+    {
+        new_func->arg_ty_ls[i] = arg_ty_ls[i];
+    }
     ctx->functions = new_func;
     return new_func;
 }


### PR DESCRIPTION
- add : 関数引数の型を保存
- add : 関数引数のvoidを読む
- add : 引数にvoidを指定して定義した関数の呼び出し
- add : 引数が多すぎるときは読み飛ばす


ex)
```
int foo(int a, int b, int c)
{
    return a;
}
int foovoid(void)
{
    return 3;
}
int main()
{
    foo(2, 3);
    foo(2, 3, 4, 5);
    foovoid(5);
}
```
このようなテストを手元では追加して
- 引数が少なすぎるときのエラー
- 定義時に引数がvoidだった関数に引数をたわしたときにエラー
- 引数が多すぎるときは読み飛ばすこと
はチェックした
