### PR TITLE
void型の定義を禁止、評価を禁止、return;を許可

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -670,7 +670,7 @@ static Node *stmt()
     {
         if (consume(";"))
         {
-            node = new_node_nop();
+            node = new_node_single(ND_RETURN, new_node_num(0));
         }
         else
         {

--- a/parser.c
+++ b/parser.c
@@ -59,6 +59,10 @@ static Node *new_node_assign(Node *lhs, Node *rhs)
     node->kind = ND_ASSIGN;
     node->lhs = lhs;
     node->rhs = rhs;
+    if (node->rhs->ty->ty == VOID)
+    {
+        error("void型の値は無視しなくてはいけません");
+    }
     node->ty = lhs->ty;
 }
 
@@ -664,8 +668,15 @@ static Node *stmt()
     Node *node;
     if (consume_rw(TK_RETURN))
     {
-        node = new_node_single(ND_RETURN, expr());
-        expect(";");
+        if (consume(";"))
+        {
+            node = new_node_nop();
+        }
+        else
+        {
+            node = new_node_single(ND_RETURN, expr());
+            expect(";");
+        }
     }
     else if (consume_rw(TK_IF))
     {

--- a/parser.c
+++ b/parser.c
@@ -522,6 +522,10 @@ static Node *defl()
         {
             error("定義式に型がありません");
         }
+        else if (ty->ty == VOID)
+        {
+            error("void型の変数は定義できません");
+        }
         Token *ident = consume_ident();
         if (consume("["))
         {
@@ -544,6 +548,11 @@ static Node *defl()
         {
             return expr();
         }
+        else if (ty->ty == VOID)
+        {
+            error("void型の変数は定義できません");
+        }
+
         Token *ident = consume_ident();
         if (consume("["))
         {
@@ -825,6 +834,11 @@ static Node *glob_var(Token *ident, Type *ty)
     node->length = ident->length;
     node->ty = ty;
     expect(";");
+    if (ty->ty == VOID)
+    {
+        error("void型の変数は定義できません");
+    }
+
     def_var(ident, ty, false);
     return node;
 }

--- a/test/func.c
+++ b/test/func.c
@@ -82,7 +82,6 @@ void setz()
 int testFuncVoid()
 {
     setz();
-    int x = setz();
     if (z != 20)
     {
         return 1;

--- a/test/func.c
+++ b/test/func.c
@@ -65,7 +65,7 @@ int foovoid(void)
 {
     return 11;
 }
-int testFuncVoid()
+int testFuncArgVoid()
 {
     if (foovoid() != 11)
     {
@@ -73,6 +73,23 @@ int testFuncVoid()
     }
     return 0;
 }
+int z;
+void setz()
+{
+    z = 20;
+    return;
+}
+int testFuncVoid()
+{
+    setz();
+
+    if (z != 20)
+    {
+        return 1;
+    }
+    return 0;
+}
+
 int main()
 {
     if (testFunc() != 0)
@@ -88,10 +105,9 @@ int main()
     {
         return 1;
     }
-    if (testFuncVoid() != 0)
+    if (testFuncArgVoid() != 0)
     {
         return 1;
     }
-
     return 0;
 }

--- a/test/func.c
+++ b/test/func.c
@@ -82,7 +82,7 @@ void setz()
 int testFuncVoid()
 {
     setz();
-
+    int x = setz();
     if (z != 20)
     {
         return 1;


### PR DESCRIPTION
- add : void型の変数定義を禁止
- add : return void test
- add : assignの右辺のvoidでエラー
- add : エラーをなくしたテスト

```
void foo(){
    return;    
}
int main(){
    int x = foo();
}
```

->void型の値は無視しなくてはいけません

```
int main(){
    void x;
}
```
->void型の変数は定義できません

は確認
