### PR TITLE
struct TAG {}:へ対応

### DIFF
--- a/hooligan.h
+++ b/hooligan.h
@@ -110,6 +110,7 @@ typedef struct Token Token;
 typedef struct Type Type;
 typedef struct Node Node;
 typedef struct Var Var;
+typedef struct Tag Tag;
 typedef struct String String;
 typedef struct Member Member;
 typedef struct Scope Scope;
@@ -215,6 +216,14 @@ struct Var
     int value;
 };
 
+struct Tag
+{
+    Tag *next;
+    char *name;
+    int length;
+    Type *ty;
+};
+
 struct String
 {
     char *p;
@@ -236,6 +245,7 @@ struct Scope
 {
     Var *variables;
     Var *constants;
+    Tag *tags;
     Type *types;
     Scope *prev;
     Scope *next;
@@ -308,6 +318,9 @@ int calc_bytes(Type *ty);
 Type *determine_expr_type(Type *lhs, Type *rhs);
 Type *def_type(Token *tok, Type *ty, bool is_local);
 Type *find_type(Token *tok);
+
+Tag *def_tag(Token *tok, Type *ty);
+Tag *find_tag(Token *tok);
 void set_struct_member(Type *ty);
 
 // scope.c

--- a/hooligan.h
+++ b/hooligan.h
@@ -308,6 +308,7 @@ int calc_bytes(Type *ty);
 Type *determine_expr_type(Type *lhs, Type *rhs);
 Type *def_type(Token *tok, Type *ty, bool is_local);
 Type *find_type(Token *tok);
+void set_struct_member(Type *ty);
 
 // scope.c
 void new_scope();

--- a/parser.c
+++ b/parser.c
@@ -496,7 +496,7 @@ static Node *expr()
     return assign();
 }
 
-static Node *deftype()
+static Node *decl_type()
 {
     Type *ty = consume_type();
     if (not(ty))
@@ -519,7 +519,7 @@ static Node *defl()
 {
     if (consume_rw(TK_TYPEDEF))
     {
-        return deftype();
+        return decl_type();
     }
     else if (consume_rw(TK_EXTERN))
     {
@@ -578,6 +578,24 @@ static Node *defl()
         }
 
         Token *ident = consume_ident();
+        if (ty->ty == STRUCT && consume("{"))
+        {
+            set_struct_member(ty);
+            def_tag(ident, ty);
+            return new_node_nop();
+        }
+        else if (ty->ty == STRUCT && ty->size == -1)
+        {
+            Token *var_name = consume_ident();
+            Tag *struct_tag = find_tag(ident);
+            if (!struct_tag)
+            {
+                error("無効なデータ型です");
+            }
+            Var *lvar = def_var(var_name, struct_tag->ty, true, false);
+            return new_node_var(lvar);
+        }
+
         if (consume("["))
         {
             int size;
@@ -941,7 +959,7 @@ static Node *def()
     Node *node;
     if (consume_rw(TK_TYPEDEF))
     {
-        node = deftype();
+        node = decl_type();
         expect(";");
         return node;
     }

--- a/parser.c
+++ b/parser.c
@@ -980,6 +980,26 @@ static Node *def()
         error("定義式に型がありません");
     }
     Token *ident = consume_ident();
+    if (ty->ty == STRUCT && consume("{"))
+    {
+        set_struct_member(ty);
+        def_tag(ident, ty);
+        expect(";");
+        return new_node_nop();
+    }
+    else if (ty->ty == STRUCT && ty->size == -1)
+    {
+        Token *var_name = consume_ident();
+        Tag *struct_tag = find_tag(ident);
+        if (!struct_tag)
+        {
+            error("無効なデータ型です");
+        }
+        Var *gvar = def_var(var_name, struct_tag->ty, false, false);
+        expect(";");
+        return new_node_var(gvar);
+    }
+
     if (consume("("))
     {
         node = func(ident, ty, is_static);

--- a/read_token.c
+++ b/read_token.c
@@ -16,6 +16,37 @@ bool consume_rw(TokenKind tk)
     return true;
 }
 
+void set_struct_member(Type *ty)
+{
+    int offset = 0;
+    Member *head = calloc(1, sizeof(Member));
+    Member *cur = head;
+    while (not(consume("}")))
+    {
+
+        Member *mem = calloc(1, sizeof(Member));
+        Type *mem_ty = consume_type();
+        Token *mem_tok = consume_ident();
+        if (consume("["))
+        {
+            int arr_size = expect_number();
+            mem_ty = new_type_array(mem_ty, arr_size);
+            expect("]");
+        }
+
+        mem->name = mem_tok->string;
+        mem->length = mem_tok->length;
+        mem->offset = offset;
+        offset += calc_bytes(mem_ty);
+        mem->ty = mem_ty;
+        cur->next = mem;
+        cur = mem;
+        expect(";");
+    }
+    ty->members = head;
+    ty->size = offset;
+}
+
 Type *consume_type()
 {
     Type *ty = find_type(token);
@@ -73,33 +104,7 @@ Type *consume_type()
     }
     if (ty->ty == STRUCT && consume("{"))
     {
-        int offset = 0;
-        Member *head = calloc(1, sizeof(Member));
-        Member *cur = head;
-        while (not(consume("}")))
-        {
-
-            Member *mem = calloc(1, sizeof(Member));
-            Type *mem_ty = consume_type();
-            Token *mem_tok = consume_ident();
-            if (consume("["))
-            {
-                int arr_size = expect_number();
-                mem_ty = new_type_array(mem_ty, arr_size);
-                expect("]");
-            }
-
-            mem->name = mem_tok->string;
-            mem->length = mem_tok->length;
-            mem->offset = offset;
-            offset += calc_bytes(mem_ty);
-            mem->ty = mem_ty;
-            cur->next = mem;
-            cur = mem;
-            expect(";");
-        }
-        ty->members = head;
-        ty->size = offset;
+        set_struct_member(ty);
     }
 
     while (consume("*"))
@@ -113,7 +118,7 @@ void expect(char *op)
 {
     if (token->kind != TK_OPERATOR || token->string[0] != op[0])
     {
-        error("'%c'ではありません", op[0]);
+        error("'%c'ではありません, got %s", op[0], token->string);
     }
     token = token->next;
 }

--- a/read_token.c
+++ b/read_token.c
@@ -16,37 +16,6 @@ bool consume_rw(TokenKind tk)
     return true;
 }
 
-void set_struct_member(Type *ty)
-{
-    int offset = 0;
-    Member *head = calloc(1, sizeof(Member));
-    Member *cur = head;
-    while (not(consume("}")))
-    {
-
-        Member *mem = calloc(1, sizeof(Member));
-        Type *mem_ty = consume_type();
-        Token *mem_tok = consume_ident();
-        if (consume("["))
-        {
-            int arr_size = expect_number();
-            mem_ty = new_type_array(mem_ty, arr_size);
-            expect("]");
-        }
-
-        mem->name = mem_tok->string;
-        mem->length = mem_tok->length;
-        mem->offset = offset;
-        offset += calc_bytes(mem_ty);
-        mem->ty = mem_ty;
-        cur->next = mem;
-        cur = mem;
-        expect(";");
-    }
-    ty->members = head;
-    ty->size = offset;
-}
-
 Type *consume_type()
 {
     Type *ty = find_type(token);

--- a/read_token.c
+++ b/read_token.c
@@ -116,7 +116,7 @@ Token *consume_ident()
 {
     if (token->kind != TK_IDENT)
     {
-        error("変数ではありません");
+        error("変数ではありません got %s", token->string);
     }
     Token *tok = token;
     token = token->next;

--- a/scope.c
+++ b/scope.c
@@ -2,7 +2,7 @@
 
 void new_scope()
 {
-    Scope *scope = calloc(1, sizeof(Node));
+    Scope *scope = calloc(1, sizeof(Scope));
     scope->prev = ctx->scope;
     ctx->scope_serial_num++;
     scope->label = ctx->scope_serial_num;

--- a/tests/struct/main.c
+++ b/tests/struct/main.c
@@ -1,0 +1,42 @@
+int testStruct()
+{
+    struct
+    {
+        int a;
+        int b;
+    } x;
+    x.a = 10;
+    if (x.a != 10)
+    {
+        return 1;
+    }
+    return 0;
+}
+
+int testStructTag()
+{
+    struct hoge
+    {
+        int a;
+        int b;
+    };
+    struct hoge x;
+    x.a = 10;
+    if (x.a != 10)
+    {
+        return 1;
+    }
+    return 0;
+}
+int main()
+{
+    if (testStruct() != 0)
+    {
+        return 1;
+    }
+    if (testStructTag() != 0)
+    {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/struct/main.c
+++ b/tests/struct/main.c
@@ -13,7 +13,7 @@ int testStruct()
     return 0;
 }
 
-int testStructTag()
+int testStructTagLocal()
 {
     struct hoge
     {
@@ -28,13 +28,37 @@ int testStructTag()
     }
     return 0;
 }
+
+struct foo
+{
+    int s;
+    int t;
+};
+
+int testStructTagGlobal()
+{
+    struct foo x;
+    x.s = 10;
+    if (x.s != 10)
+    {
+        return 1;
+    }
+    return 0;
+}
+
 int main()
 {
     if (testStruct() != 0)
     {
         return 1;
     }
-    if (testStructTag() != 0)
+
+    if (testStructTagLocal() != 0)
+    {
+        return 1;
+    }
+
+    if (testStructTagGlobal() != 0)
     {
         return 1;
     }

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -142,6 +142,13 @@ Token *tokenize(char *p)
         }
 
         // ブロックコメントをスキップ
+        if (strncmp(p, "#", 1) == 0)
+        {
+            p += 1;
+            while (*p != '\n')
+                p++;
+            continue;
+        }
         if (strncmp(p, "/*", 2) == 0)
         {
             char *q = strstr(p + 2, "*/");
@@ -201,7 +208,7 @@ Token *tokenize(char *p)
         {
             int i = 0;
             char *p_top = p;
-            while (isident(*p))
+            while (isident(*p) || isdigit(*p))
             {
                 i++;
                 p++;

--- a/type.c
+++ b/type.c
@@ -161,6 +161,35 @@ Type *def_type(Token *tok, Type *ty, bool is_local)
     return new_type;
 }
 
+Tag *find_tag(Token *tok)
+{
+    for (Scope *scope = ctx->scope; scope; scope = scope->prev)
+    {
+        for (Tag *tag = scope->tags; tag; tag = tag->next)
+        {
+            if (tag->length == tok->length && memcmp(tag->name, tok->string, tag->length) == 0)
+            {
+                return tag;
+            }
+        }
+    }
+    return NULL;
+}
+
+Tag *def_tag(Token *tok, Type *ty)
+{
+    Tag *new_tag = calloc(1, sizeof(Tag));
+    new_tag->name = tok->string;
+    new_tag->length = tok->length;
+    new_tag->ty = calloc(1, sizeof(Type));
+    new_tag->ty->ty = ty->ty;
+    new_tag->ty->members = ty->members;
+    new_tag->ty->size = ty->size;
+    new_tag->next = ctx->scope->tags;
+    ctx->scope->tags = new_tag;
+    return new_tag;
+}
+
 void set_struct_member(Type *ty)
 {
     int offset = 0;

--- a/type.c
+++ b/type.c
@@ -63,6 +63,7 @@ Type *new_type_struct()
         ty = calloc(1, sizeof(Type));
         ty->ty = STRUCT;
     }
+    ty->size = -1;
     return ty;
 }
 

--- a/type.c
+++ b/type.c
@@ -160,3 +160,34 @@ Type *def_type(Token *tok, Type *ty, bool is_local)
     ctx->scope->types = new_type;
     return new_type;
 }
+
+void set_struct_member(Type *ty)
+{
+    int offset = 0;
+    Member *head = calloc(1, sizeof(Member));
+    Member *cur = head;
+    while (not(consume("}")))
+    {
+
+        Member *mem = calloc(1, sizeof(Member));
+        Type *mem_ty = consume_type();
+        Token *mem_tok = consume_ident();
+        if (consume("["))
+        {
+            int arr_size = expect_number();
+            mem_ty = new_type_array(mem_ty, arr_size);
+            expect("]");
+        }
+
+        mem->name = mem_tok->string;
+        mem->length = mem_tok->length;
+        mem->offset = offset;
+        offset += calc_bytes(mem_ty);
+        mem->ty = mem_ty;
+        cur->next = mem;
+        cur = mem;
+        expect(";");
+    }
+    ty->members = head;
+    ty->size = offset;
+}


### PR DESCRIPTION
- update : 変数名の先頭以外に数字を許容
- add : structのデータ型の決定の切り出し
- mv : set_struct_memberをtype.cへ
- add : def_tag, find_tag
- add : tagの宣言
- add : new_structではsizeを-1に設定し直す
- add : エラーログの改善
- fix : scopeのcallocの大きさ
- add : struct TAG {};のパーサー
- add : struct TAG {};のテスト
