### PR TITLE
fix: extract_dirでの終端文字忘れ

### DIFF
--- a/unittest/util/stdout.txt
+++ b/unittest/util/stdout.txt
@@ -5,4 +5,4 @@ hofugafugagehoge
 hogehogefugafuga
 hogehoge/
 fugafuga/hogehoge/
-
+unittest/preprocessing_tokenize/include/

--- a/unittest/util/test.c
+++ b/unittest/util/test.c
@@ -22,8 +22,9 @@ int testExtractDir()
 {
     char *s1 = "hogehoge/hoge";
     char *s2 = "fugafuga/hogehoge/fuga.c";
-    char *s3 = "hoge.c";
-    char *s4 = "";
+    char *s3 = "unittest/preprocessing_tokenize/include/10.c";
+    char *s4 = "hoge.c";
+    char *s5 = "";
     char *s;
     s = extract_dir(s1);
     printf("%s\n", s);
@@ -32,6 +33,8 @@ int testExtractDir()
     s = extract_dir(s3);
     printf("%s\n", s);
     s = extract_dir(s4);
+    printf("%s\n", s);
+    s = extract_dir(s5);
     printf("%s\n", s);
     return 0;
 }

--- a/util.c
+++ b/util.c
@@ -68,9 +68,9 @@ char *extract_dir(char *p)
         return "";
     int preLength = strrchr(p, '/') - p + 1;
     int postLength = strlen(p) - preLength;
-    char *p1 = calloc(1, preLength);
+    char *p1 = calloc(1, preLength + 1);
     memcpy(p1, p, preLength);
-    char *p2 = calloc(1, postLength);
+    char *p2 = calloc(1, postLength + 1);
     memcpy(p2, p + preLength, postLength);
     return p1;
 }


### PR DESCRIPTION
`extract_dir("unittest/preprocessing_tokenize/include/10.c")`が`"unittest/preprocessing_tokenize/include/!"`となっていた。
謎の`!`挿入だが、`"unittest/tokenizer2/include/10.c"`とかは全く問題なかった。
終端文字をつけ忘れるとよくわかんないバグが発生する？
