### PR TITLE
オプションパーサーを実装

### DIFF
--- a/bin/hcli
+++ b/bin/hcli
@@ -56,7 +56,7 @@ compile() {
         gcc -masm=intel -S "$@"
     else
         if [[ VERBOSE -eq 1 ]]; then
-            IS_VERBOSE=1 ./bin/hcc$COMPILER_GENERATION "$@"
+            ./bin/hcc$COMPILER_GENERATION -v "$@"
         else
             ./bin/hcc$COMPILER_GENERATION "$@"
         fi

--- a/src/generator.c
+++ b/src/generator.c
@@ -523,7 +523,7 @@ void gen_block(Node *node)
 
 static void logging(Node *node)
 {
-    if (!is_verbose)
+    if (!opts->is_verbose)
         return;
     int lhs = -1;
     int rhs = -1;
@@ -871,7 +871,7 @@ void gen_asm_intel()
     println(".intel_syntax noprefix");
     println(".data");
     program();
-    if (is_verbose)
+    if (opts->is_verbose)
     {
         printf("\x1b[33mSTART GENERATING\x1b[0m\n");
     }
@@ -928,7 +928,7 @@ void gen_asm_intel()
     {
         gen(funcs[j]);
     }
-    if (is_verbose)
+    if (opts->is_verbose)
     {
         printf("\x1b[33mEND GENERATING\x1b[0m\n");
     }

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -118,6 +118,7 @@ typedef enum
 } RegisterName;
 
 // type definition
+typedef struct Option Option;
 typedef struct PPToken PPToken;
 typedef struct Macro Macro;
 typedef struct PPContext PPContext;
@@ -129,6 +130,11 @@ typedef struct String String;
 typedef struct Member Member;
 typedef struct Scope Scope;
 typedef struct Context Context;
+
+struct Option
+{
+    bool is_verbose;
+};
 
 struct PPToken
 {

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -317,12 +317,12 @@ struct Context
 };
 
 // Declaration of global variables
+extern Option *opts;
 extern PPContext *pp_ctx;
 extern Token *token;
 extern Node *nodes[500];
 extern Context *ctx;
 extern FILE *output;
-extern bool is_verbose;
 
 // Declaration of functions
 // read_token.c

--- a/src/main.c
+++ b/src/main.c
@@ -5,26 +5,51 @@ Token *token;
 Node *nodes[500];
 Context *ctx;
 FILE *output;
+Option *opts;
+int file_count;
+char *files[20];
+
+void analyze_arguments(int argc, char **argv)
+{
+    opts = calloc(1, sizeof(Option));
+    file_count = 0;
+    for (int i = 1; i < argc; i++)
+    {
+        char *arg = argv[i];
+        if (*arg == '-')
+        {
+            if (*(arg + 1) == 'v')
+            {
+                opts->is_verbose = true;
+                is_verbose = true;
+            }
+            else
+            {
+                printf("%c\n", *(arg + 1));
+                error("不正なオプションです");
+            }
+        }
+        else
+        {
+            files[file_count] = arg;
+            file_count++;
+        }
+    }
+
+    if (file_count == 0)
+    {
+        error("ファイル名を指定してください");
+    }
+}
 
 int main(int argc, char **argv)
 {
-    if (argc == 1)
-    {
-        fprintf(stderr, "ファイル名を指定してください\n");
-        exit(1);
-    }
-    if (getenv("IS_VERBOSE") != NULL)
-    {
-        is_verbose = true;
-    }
-    else
-    {
-        is_verbose = false;
-    }
-    for (int i = 1; i < argc; i++)
+    analyze_arguments(argc, argv);
+
+    for (int i = 0; i < file_count; i++)
     {
         token = NULL;
-        char *path = argv[i];
+        char *path = files[i];
         char *dirname = extract_dir(path);
         char *filename = extract_filename(path);
         char *p = read_file(path);

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,5 @@
 #include "hooligan.h"
 
-bool is_verbose;
 Token *token;
 Node *nodes[500];
 Context *ctx;
@@ -21,7 +20,6 @@ void analyze_arguments(int argc, char **argv)
             if (*(arg + 1) == 'v')
             {
                 opts->is_verbose = true;
-                is_verbose = true;
             }
             else
             {
@@ -53,7 +51,7 @@ int main(int argc, char **argv)
         char *dirname = extract_dir(path);
         char *filename = extract_filename(path);
         char *p = read_file(path);
-        if (is_verbose)
+        if (opts->is_verbose)
         {
             printf("%sのコンパイルを開始します\n", path);
         }
@@ -75,7 +73,7 @@ int main(int argc, char **argv)
         gen_asm_intel();
 
         fclose(output);
-        if (is_verbose)
+        if (opts->is_verbose)
         {
             printf("\x1b[32mCompilation Succeded! output: %s\x1b[0m\n", output_filename);
         }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,7 +1,7 @@
 #include "hooligan.h"
 static void logging(Node *node)
 {
-    if (is_verbose)
+    if (opts->is_verbose)
     {
         printf("Kind: %d\n", node->kind);
     }
@@ -1229,7 +1229,7 @@ static Node *def()
 
 void program()
 {
-    if (is_verbose)
+    if (opts->is_verbose)
     {
         printf("\x1b[33mSTART PARSING\x1b[0m\n");
     }
@@ -1245,7 +1245,7 @@ void program()
         ctx->offset = 0;
     }
     nodes[i + 1] = NULL;
-    if (is_verbose)
+    if (opts->is_verbose)
     {
         printf("\x1b[33mEND PARSING\x1b[0m\n");
     }


### PR DESCRIPTION
gccに近づけるために自由にオプションを付与できるようにしたい

試しに環境変数渡ししていたverboseオプションを`-v`として渡せるようにしてみた