### PR TITLE
error_atの実装

### DIFF
--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -392,6 +392,7 @@ int get_unique_num();
 void error(char *fmt);
 void error1(char *fmt, char *v1);
 void error2(char *fmt, char *v1, char *v2);
+void error_at(char *loc, char *msg);
 char *insert_str(char *src, int pos, char *target);
 char *join_str(char *pre, char *post);
 char *read_file(char *path);

--- a/src/parser.c
+++ b/src/parser.c
@@ -247,7 +247,7 @@ static Node *ident()
         Type *ty = find_defined_type(ident);
         if (!ty)
         {
-            error("識別子が解決できませんでした");
+            error_at(ident->string, "識別子が解決できませんでした");
         }
         Node *node = calloc(1, sizeof(Node));
         node->ty = ty;

--- a/src/preprocessor.c
+++ b/src/preprocessor.c
@@ -167,7 +167,7 @@ PPToken *decompose_to_pp_token(char *p)
         {
             char *q = strstr(p + 2, "*/");
             if (!q)
-                error("コメントが閉じられていません");
+                error_at(p, "コメントが閉じられていません");
             p = q + 2;
             continue;
         }
@@ -180,7 +180,7 @@ PPToken *decompose_to_pp_token(char *p)
             p++;
             if (!isdirective(p))
             {
-                error("未定義のプリプロセッシング命令文です");
+                error_at(p, "未定義のプリプロセッシング命令文です");
             }
             int directive_index;
             for (int i = 0; i < preprocessing_directive_list_count; i++)
@@ -218,7 +218,7 @@ PPToken *decompose_to_pp_token(char *p)
                     }
                     if (cur->kind != PPTK_HN)
                     {
-                        error("不正なinclude文です");
+                        error_at(p, "不正なinclude文です");
                     }
                 }
                 else if (*p == '"')
@@ -238,12 +238,12 @@ PPToken *decompose_to_pp_token(char *p)
                     }
                     if (cur->kind != PPTK_HN)
                     {
-                        error("不正なinclude文です");
+                        error_at(p, "不正なinclude文です");
                     }
                 }
                 else
                 {
-                    error("不正なinclude文です");
+                    error_at(p, "不正なinclude文です");
                 }
             }
             else if (directive_index == 1)
@@ -328,7 +328,7 @@ PPToken *decompose_to_pp_token(char *p)
             }
             else
             {
-                error("未定義のプリプロセッシング命令文です");
+                error_at(p, "未定義のプリプロセッシング命令文です");
             }
             while (*p != '\n')
                 p++;
@@ -346,7 +346,7 @@ PPToken *decompose_to_pp_token(char *p)
                 {
                     if (!*(p + 1))
                     {
-                        error("エスケープ文字のあとに文字がありません");
+                        error_at(p, "エスケープ文字のあとに文字がありません");
                     }
                     p += 2;
                     i += 2;
@@ -362,7 +362,7 @@ PPToken *decompose_to_pp_token(char *p)
                 }
             }
             if (*p != '"')
-                error("ダブルクォテーションが閉じていません");
+                error_at(p, "ダブルクォテーションが閉じていません");
 
             p++;
             cur = new_token(PPTK_STRING, cur, p_top);
@@ -389,7 +389,7 @@ PPToken *decompose_to_pp_token(char *p)
             p++;
             if (*p != '\'')
             {
-                error("シングルクォーテーションが閉じていません");
+                error_at(p, "シングルクォーテーションが閉じていません");
             }
             p++;
             continue;
@@ -486,7 +486,7 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                 PPToken *hn_tok = cur->next->next;
                 if (hn_tok->kind != PPTK_HN)
                 {
-                    error("不正なinclude文です");
+                    error_at(cur->str, "不正なinclude文です");
                 }
                 char *p = hn_tok->str;             // < or "
                 char *p_end = p + hn_tok->len - 1; // > or "
@@ -556,11 +556,11 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                 {
                     if (target->len == replace->len && strncmp(target->str, replace->str, target->len) == 0)
                     {
-                        error("target == replace　のマクロは定義できません");
+                        error_at(cur->str, "target == replace　のマクロは定義できません");
                     }
                     if (find_macro(target->str, target->len) != NULL)
                     {
-                        error("マクロの二重定義です");
+                        error_at(cur->str, "マクロの二重定義です");
                     }
                 }
                 else if (target->kind == PPTK_IDENT && replace->kind == PPTK_DUMMY)
@@ -568,12 +568,12 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                     // #define identに対応
                     if (find_macro(target->str, target->len) != NULL)
                     {
-                        error("マクロの二重定義です");
+                        error_at(cur->str, "マクロの二重定義です");
                     }
                 }
                 else
                 {
-                    error("不正なdefine文です");
+                    error_at(cur->str, "不正なdefine文です");
                 }
                 Macro *mac = calloc(1, sizeof(Macro));
                 mac->target = target;
@@ -603,7 +603,7 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                     PPToken *before_endif = fetch_before_endif(target);
                     if (before_endif == NULL)
                     {
-                        error("ifdefの後にはendifが必要です");
+                        error_at(cur->str, "ifdefの後にはendifが必要です");
                     }
                     PPToken *after_endif = before_endif->next->next->next;
                     before_endif->next = after_endif;
@@ -624,7 +624,7 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                     PPToken *before_endif = fetch_before_endif(target);
                     if (before_endif == NULL)
                     {
-                        error("ifdefの後にはendifが必要です");
+                        error_at(cur->str, "ifdefの後にはendifが必要です");
                     }
                     PPToken *after_endif = before_endif->next->next->next;
                     if (prev == cur)
@@ -650,7 +650,7 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                     PPToken *before_endif = fetch_before_endif(target);
                     if (before_endif == NULL)
                     {
-                        error("ifndefの後にはendifが必要です");
+                        error_at(cur->str, "ifndefの後にはendifが必要です");
                     }
                     PPToken *after_endif = before_endif->next->next->next;
                     before_endif->next = after_endif;
@@ -671,7 +671,7 @@ PPToken *preprocess_directives(char *base_dir, PPToken *tok)
                     PPToken *before_endif = fetch_before_endif(target);
                     if (before_endif == NULL)
                     {
-                        error("iffdefの後にはendifが必要です");
+                        error_at(cur->str, "iffdefの後にはendifが必要です");
                     }
                     PPToken *after_endif = before_endif->next->next->next;
                     if (prev == cur)

--- a/src/read_token.c
+++ b/src/read_token.c
@@ -70,12 +70,12 @@ Type *consume_type()
             }
             if (i == 0)
             {
-                error("識別子が必要です");
+                error_at(token->string, "識別子が必要です");
             }
         }
         else
         {
-            error("識別子が必要です");
+            error_at(token->string, "識別子が必要です");
         }
     }
     else
@@ -151,7 +151,7 @@ void expect(char *op)
 int expect_number()
 {
     if (token->kind != TK_NUMBER)
-        error("数字ではありません");
+        error_at(token->string, "数字ではありません");
     int value = token->value;
     token = token->next;
     return value;
@@ -161,7 +161,7 @@ int expect_char()
 {
     if (token->kind != TK_CHARACTER)
     {
-        error("文字ではありません");
+        error_at(token->string, "文字ではありません");
     }
     int value = token->value;
     token = token->next;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -116,7 +116,7 @@ static TokenKind find_reserved_word(char *p)
         if (strncmp(p, word, len) == 0 && !(isident(*(p + len))))
             return tk;
     }
-    error("予約語ではありません");
+    error_at(p, "予約語ではありません");
     return -1; // Not Found
 }
 
@@ -148,7 +148,7 @@ Token *tokenize(PPToken *pptok)
             cur->value = pptok->val;
             break;
         case PPTK_HN:
-            error("未処理のプリプロセッシングトークン列です");
+            error_at(pptok->str, "未処理のプリプロセッシングトークン列です");
             break;
         case PPTK_IDENT:
             if (isreservedword2(pptok->str, pptok->len))
@@ -171,7 +171,7 @@ Token *tokenize(PPToken *pptok)
         case PPTK_PUNC:
             if (!isoperator(pptok->str))
             {
-                error("不正なトークンです");
+                error_at(pptok->str, "不正なトークンです");
             }
             for (int i = 0; i < operator_list_count; i++)
             {

--- a/src/util.c
+++ b/src/util.c
@@ -21,6 +21,30 @@ void error2(char *fmt, char *v1, char *v2)
     exit(1);
 }
 
+void error_at(char *loc, char *msg)
+{
+    fprintf(stderr, "エラーが発生しました");
+    // 前と後ろの改行コードを調べてエラーになった行を抜き出せるようにする
+    char *start = loc;
+    while (*start != '\n')
+    {
+        start -= 1;
+    }
+    char *end = loc;
+    while (*end != '\n')
+    {
+        end += 1;
+    }
+    int countOfLine = end - start;
+    int countToLoc = loc - start;
+    fprintf(stderr, "%.*s\n", countOfLine, start);
+    fprintf(stderr, "%*s", countToLoc, " "); // pos個の空白を出力
+    fprintf(stderr, "^ ");
+    fprintf(stderr, "%s", msg);
+    fprintf(stderr, "%s", end);
+    exit(1);
+}
+
 char *insert_str(char *src, int pos, char *target)
 {
     char *res = calloc(1, strlen(src) + strlen(target) + 1);
@@ -71,7 +95,7 @@ char *remove_extension(char *p)
         preLength = strchr(p, '.') - p;
     }
     char *res = calloc(1, preLength + 1);
-    memcpy(res, p, preLength); 
+    memcpy(res, p, preLength);
     return res;
 }
 


### PR DESCRIPTION
close #62 

parser.cやgenerator.cではerror_atが使用できない
これはNode型が入力文字列へのポインタを持たないため
この問題の解決策は思案中