### PR TITLE
cleanコマンドが2つあったので振る舞いを統一

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ selfhost: first
 	rm *.s
 
 clean:
-	@rm -f bin/hcc* *.o src/*.o *~ tmp* *.s
+	@rm -f bin/hcc* *.o src/*.o *~ tmp* *.s a.out core.*
 .PHONY: test clean selfhost

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ selfhost: first
 	rm *.s
 
 clean:
-	@rm -f bin/hcc* *.o *~ tmp* *.s
+	@rm -f bin/hcc* *.o src/*.o *~ tmp* *.s
 .PHONY: test clean selfhost

--- a/bin/hcli
+++ b/bin/hcli
@@ -27,10 +27,7 @@ display_help() {
 }
 
 clean() {
-    find . -name '*.s' -exec rm -f {} +
-    find . -name 'a.out' -exec rm -f {} +
-    find . -name 'core.*' -exec rm -f {} +
-    rm -f bin/hcc*
+    make clean
 }
 
 clean_assembly() {


### PR DESCRIPTION
`make clean`と`hcli clean`の2つがあったので、`hcli clean`は`make clean`のエイリアスとしました。
合わせて[ここ](https://github.com/tychy/hooligan/pull/265#discussion_r728899013)で議論してたsrc以下のオブジェクトファイルがクリーンアップされない問題も解消しています。