### PR TITLE
depthを削除

### DIFF
--- a/src/generator.c
+++ b/src/generator.c
@@ -45,29 +45,24 @@ void println(char *fmt, ...)
     va_end(ap);
 }
 
-int depth;
 static void push(RegisterName r)
 {
     println("  push %s", reg64[r]);
-    depth++;
 }
 
 static void push_val(int val)
 {
     println("  push %d", val);
-    depth++;
 }
 
 static void push_str_addr(int label)
 {
     println("  push offset .LC%d", label);
-    depth++;
 }
 
 static void pop(RegisterName r)
 {
     println("  pop %s", reg64[r]);
-    depth--;
 }
 
 static void gen_va_start(Node *node)
@@ -259,10 +254,7 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         count--;
         pop(count);
     }
-    if (depth % 2 == 0)
-    {
-        println("  sub rsp, 8");
-    }
+
     println("  mov al, 0");
     if (node->is_static)
     {
@@ -273,10 +265,6 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         println("  call %.*s", node->length, node->name);
     }
 
-    if (depth % 2 == 0)
-    {
-        println("  add rsp, 8");
-    }
     push(RG_RAX);
 }
 
@@ -721,7 +709,6 @@ static void gen(Node *node)
                 println("  subss xmm0, xmm1");
             println("  movss 8[rsp], xmm0");
             println("  add rsp, 8");
-            depth--;
             return;
         }
         else
@@ -836,7 +823,6 @@ static void gen(Node *node)
             println("  mulss xmm0, xmm1");
             println("  movss 8[rsp], xmm0");
             println("  add rsp, 8");
-            depth--;
         }
         else
         {
@@ -855,7 +841,6 @@ static void gen(Node *node)
             println("  divss xmm0, xmm1");
             println("  movss 8[rsp], xmm0");
             println("  add rsp, 8");
-            depth--;
         }
         else
         {
@@ -879,7 +864,6 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
-            depth -= 2;
             println("  ucomiss xmm0, xmm1");
             println("  sete al");
         }
@@ -900,7 +884,6 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
-            depth -= 2;
             println("  ucomiss xmm0, xmm1");
             println("  setne al");
         }
@@ -921,7 +904,6 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
-            depth -= 2;
             println("  comiss xmm0, xmm1");
             println("  setnb al");
         }
@@ -941,7 +923,6 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
-            depth -= 2;
 
             println("  comiss xmm1, xmm0");
             println("  setnb al");
@@ -962,7 +943,6 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
-            depth -= 2;
 
             println("  comiss xmm0, xmm1");
             println("  seta al");
@@ -984,7 +964,6 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
-            depth -= 2;
 
             println("  comiss xmm1, xmm0");
             println("  seta al");


### PR DESCRIPTION
関数呼び出しABIでは関数呼び出し時にrspが16の倍数でなくてはならないという規約が存在する。
その規約に従うためにdepthという、変数でrspの状態を管理していたが、なくても動くことが判明したので削除。

Ubuntu20.04環境下における`vsprintf`を呼び出すとセグフォすることから、rspを16の倍数にアライメントするという役割を果たせていないと判断した。

## 参考情報
Ubuntu 18.04においては`vsprintf`を呼び出してもセグフォにならない