### PR TITLE
関数呼び出し時のアライメント再実装

### DIFF
--- a/src/generator.c
+++ b/src/generator.c
@@ -45,24 +45,29 @@ void println(char *fmt, ...)
     va_end(ap);
 }
 
+int depth;
 static void push(RegisterName r)
 {
     println("  push %s", reg64[r]);
+    depth++;
 }
 
 static void push_val(int val)
 {
     println("  push %d", val);
+    depth++;
 }
 
 static void push_str_addr(int label)
 {
     println("  push offset .LC%d", label);
+    depth++;
 }
 
 static void pop(RegisterName r)
 {
     println("  pop %s", reg64[r]);
+    depth--;
 }
 
 static void gen_va_start(Node *node)
@@ -254,7 +259,10 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         count--;
         pop(count);
     }
-
+    if (depth % 2 == 0)
+    {
+        println("  sub rsp, 8");
+    }
     println("  mov al, 0");
     if (node->is_static)
     {
@@ -265,6 +273,10 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         println("  call %.*s", node->length, node->name);
     }
 
+    if (depth % 2 == 0)
+    {
+        println("  add rsp, 8");
+    }
     push(RG_RAX);
 }
 
@@ -709,6 +721,7 @@ static void gen(Node *node)
                 println("  subss xmm0, xmm1");
             println("  movss 8[rsp], xmm0");
             println("  add rsp, 8");
+            depth--;
             return;
         }
         else
@@ -823,6 +836,7 @@ static void gen(Node *node)
             println("  mulss xmm0, xmm1");
             println("  movss 8[rsp], xmm0");
             println("  add rsp, 8");
+            depth--;
         }
         else
         {
@@ -841,6 +855,7 @@ static void gen(Node *node)
             println("  divss xmm0, xmm1");
             println("  movss 8[rsp], xmm0");
             println("  add rsp, 8");
+            depth--;
         }
         else
         {
@@ -864,6 +879,7 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
+            depth -= 2;
             println("  ucomiss xmm0, xmm1");
             println("  sete al");
         }
@@ -884,6 +900,7 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
+            depth -= 2;
             println("  ucomiss xmm0, xmm1");
             println("  setne al");
         }
@@ -904,6 +921,7 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
+            depth -= 2;
             println("  comiss xmm0, xmm1");
             println("  setnb al");
         }
@@ -923,6 +941,7 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
+            depth -= 2;
 
             println("  comiss xmm1, xmm0");
             println("  setnb al");
@@ -943,6 +962,7 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
+            depth -= 2;
 
             println("  comiss xmm0, xmm1");
             println("  seta al");
@@ -964,6 +984,7 @@ static void gen(Node *node)
             println("  movss xmm0, 8[rsp]");
             println("  movss xmm1, [rsp]");
             println("  add rsp, 16");
+            depth -= 2;
 
             println("  comiss xmm1, xmm0");
             println("  seta al");

--- a/src/generator.c
+++ b/src/generator.c
@@ -259,7 +259,7 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         count--;
         pop(count);
     }
-    if (depth % 2 == 0)
+    if (depth % 2 != 0)
     {
         println("  sub rsp, 8");
     }
@@ -273,7 +273,7 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         println("  call %.*s", node->length, node->name);
     }
 
-    if (depth % 2 == 0)
+    if (depth % 2 != 0)
     {
         println("  add rsp, 8");
     }
@@ -1083,6 +1083,7 @@ void gen_asm_intel()
     for (int j = 0; j < func_count; j++)
     {
         gen(funcs[j]);
+        depth = 0;
     }
     if (opts->is_verbose)
     {

--- a/tests/vsprintf/main.c
+++ b/tests/vsprintf/main.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+void p(char *buf)
+{
+}
+
+char *prints1(char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    char *raw = calloc(100, sizeof(char));
+    vsprintf(raw, fmt, ap);
+    p(raw);
+    va_end(ap);
+    return raw;
+}
+
+char *prints2(char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    char *raw = calloc(100, sizeof(char));
+    vsprintf(raw, fmt, ap);
+    int a = 3;
+    p(raw);
+    va_end(ap);
+    return raw;
+}
+
+int main()
+{
+    char *s = prints1("hogehoge");
+    char *s1 = prints2("fugafuga");
+    printf("%s\n", s);
+    printf("%s\n", s1);
+    return 0;
+}

--- a/tests/vsprintf/out
+++ b/tests/vsprintf/out
@@ -1,0 +1,2 @@
+hogehoge
+fugafuga


### PR DESCRIPTION
Ubuntu 20.04においてvsprintfは関数呼び出し時のアライメントができていないとセグフォする。
そのテストを追加して、関数呼び出し時のアライメントを正しくできるように修正するPR。
