### PR TITLE
アセンブリを機械語に変換するときのオプションを-no-pieに変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS:=-std=c11 -static
+CFLAGS:=-std=c11 -no-pie
 SOURCE:=$(wildcard src/*.c)
 OBJS:=$(SOURCE:.c=.o)
 
@@ -19,7 +19,7 @@ else
 endif
 selfhost: first
 	@$(COMPILER) $(SOURCE) && \
-	find *.s | xargs cc -static -o $(OUTPUT) && \
+	find *.s | xargs cc -no-pie -o $(OUTPUT) && \
 	rm *.s
 
 clean:

--- a/bin/hcli
+++ b/bin/hcli
@@ -55,7 +55,7 @@ runtest() {
         printf "%s" "$dn"
         cfiles=$(find "$dn"/*.c)
         compile $cfiles # Quoteすると複数ファイルが一つの引数として扱われてしまう
-        find ./*.s | xargs cc -static -g -O0
+        find ./*.s | xargs cc -no-pie -g -O0
         expectedout=$(cat "$dn"/out)
         set +e
         stdout=$(./a.out)
@@ -142,14 +142,14 @@ elif [ "${param[0]}" = "src" ] || [ "${param[0]}" = "s" ]; then
     done
 elif [ "${param[0]}" = "exec" ] || [ "${param[0]}" = "e" ]; then
     compile "${param[@]:1}"
-    find ./*.s | xargs cc -static -g -O0
+    find ./*.s | xargs cc -no-pie -g -O0
     set +e
     ./a.out
     echo "結果: $?"
     set -e
 elif [ "${param[0]}" = "debug" ]; then
     compile "${@:1}"
-    find ./*.s | xargs cc -static -g -O0
+    find ./*.s | xargs cc -no-pie -g -O0
     gdb a.out
 elif [ "${param[0]}" = "test" ] || [ "${param[0]}" = "t" ]; then
     runtest


### PR DESCRIPTION
色々調べてたら-no-pieでも動くことに気付きました。
-staticはかなり時間がかかるので変更したいと思います。

[before]
```
$hyperfine "./bin/hcli test -g 10"                                                                                                                                              [featreu/option_no_pie]
Benchmark #1: ./bin/hcli test -g 10
  Time (mean ± σ):      8.060 s ±  0.229 s    [User: 4.102 s, System: 1.485 s]
  Range (min … max):    7.667 s …  8.500 s    10 runs
```

[after]
```
$hyperfine "./bin/hcli test -g 10"                                                                                                                                              [featreu/option_no_pie]
Benchmark #1: ./bin/hcli test -g 10
  Time (mean ± σ):      4.894 s ±  0.095 s    [User: 2.608 s, System: 0.940 s]
  Range (min … max):    4.814 s …  5.064 s    10 runs
```

倍速までは行かないけど30%くらい早くなってます。