### PR TITLE
Use xmm register in passing float value

### DIFF
--- a/src/generator.c
+++ b/src/generator.c
@@ -15,6 +15,7 @@ static void gen_float(Node *node)
     }
     push_str_addr(node->f_label); // 流用しているので関数名を変えるべき
     pop(ILRG_RAX);
+    new_il_sentence_raw("  movss xmm0, DWORD PTR [rax]");
     new_il_sentence_raw("  mov eax, [rax]");
     push(ILRG_RAX);
     char *z = calloc(node->f_numzero, sizeof(char));
@@ -347,7 +348,6 @@ static void gen_function_def(Node *node) // こっちがgen_functionという名
         }
         else
         {
-
             error("引数の数が多すぎます");
         }
         count++;
@@ -415,7 +415,7 @@ static void gen_assign(Node *node)
     }
     else if (is_float(node->ty))
     {
-        new_il_sentence_raw("  mov [rax], edi");
+        new_il_sentence_raw("  movss DWORD PTR [rax], xmm0");
     }
     else if (is_char(node->ty))
     {

--- a/src/generator.c
+++ b/src/generator.c
@@ -341,13 +341,7 @@ static void gen_function_def(Node *node) // こっちがgen_functionという名
             }
             else
             {
-                if (is_int(arg->ty))
-                    reg = reg32[count - count_float];
-                else if (is_char(arg->ty))
-                    reg = reg8[count - count_float];
-                else
-                    reg = reg64[count - count_float];
-
+                reg = get_register_from_type(count - count_float, arg->ty);
                 new_il_sentence_raw("  mov [rax], %s", reg);
             }
         }

--- a/src/generator/register.c
+++ b/src/generator/register.c
@@ -45,3 +45,24 @@ static char *xmm[9] = {
     "xmm7",
     "xmm8",
 };
+
+static char *get_register_from_type(int index, Type *ty)
+{
+    if (is_float(ty))
+    {
+        return xmm[index];
+    }
+    else
+    {
+        switch (calc_bytes(ty))
+        {
+        case 1:
+            return reg8[index];
+        case 4:
+            return reg32[index];
+        case 8:
+        default:
+            return reg64[index];
+        }
+    }
+}

--- a/tests/float/main.c
+++ b/tests/float/main.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 int testFloatDefine()
 {
     float x;
@@ -311,6 +313,18 @@ int testFloatFuncCall()
     return 0;
 }
 
+int testStrtof()
+{
+    float y = 1.1111;
+    char *hoge;
+    float x = strtof("1.111", &hoge);
+    if (y - x >= 0.01)
+    {
+        return 1;
+    }
+    return 0;
+}
+
 int main()
 {
     if (testFloatDefine() != 0)
@@ -344,6 +358,11 @@ int main()
     }
 
     if (testFloatFuncCall() != 0)
+    {
+        return 1;
+    }
+
+    if (testStrtof() != 0)
     {
         return 1;
     }


### PR DESCRIPTION
In gcc, xmm register is used when a function returns float value according to the ABI.
So, I think hooligan also complies that rule.

