### PR TITLE
add -fPIC option in compiling source file for shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ tmp
 .envrc
 bin/*
 !bin/hcli
+!bin/*.sh
 sandbox
 core*

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,7 @@ else
 	COMPILER:=bin/hcc1
 endif
 selfhost: first
-	@$(COMPILER) $(SOURCE) && \
-	cc ./*.s $(CFLAGS) $(LIBFLAGS) -o $(OUTPUT) && \
-	rm *.s
+	@$(COMPILER) $(SOURCE) && ./bin/assemble.sh && mv a.out $(OUTPUT)
 
 lib: $(LIBOBJS)
 	@cc -shared -std=c11 -o bin/libhooligan.so $(LIBOBJS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS:=-std=c11 -no-pie -MMD
+CFLAGS:=-std=c11 -MMD
 LIBFLAGS:=-l hooligan -L./bin
 SOURCE:=$(wildcard src/*.c)
 OBJS:=$(SOURCE:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ selfhost: first
 
 lib: $(LIBOBJS)
 	@cc -shared -std=c11 -o bin/libhooligan.so $(LIBOBJS)
-$(LIBOBJS): src/hooligan.h
+$(LIBOBJS): %.o: %.c 
+	cc $< $(CFLAGS) -c -fPIC -o $@
 
 clean:
 	@rm -f bin/hcc* *.o src/*.o src/*.d lib/*.o lib/*.d *~ tmp* *.s a.out core.* bin/*.so

--- a/bin/assemble.sh
+++ b/bin/assemble.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# TODO This shell scipt should be integrated into hcc
+set -eu
+
+lib_path=($(dirname /usr/lib/x86_64-linux-gnu/crti.o))
+gcc_lib_path=($(dirname /usr/lib/gcc/x86_64-linux-gnu/*/crtbegin.o))
+
+rm -f ./*.o
+find ./*.s | while read -r fn; do
+    as -c "$fn" -o "${fn%.s}".o
+done
+ld -o a.out -m elf_x86_64 "${lib_path[0]}"/crt1.o "${lib_path[0]}"/crti.o "${gcc_lib_path[0]}"/crtbegin.o \
+    -L"${lib_path[0]}" -L/usr/lib64 -L/lib64 \
+    -L"${gcc_lib_path[0]}" -dynamic-linker /lib64/ld-linux-x86-64.so.2 ./*.o \
+    -lc -lgcc --as-needed -lgcc_s --no-as-needed \
+    "${gcc_lib_path[0]}"/crtend.o "${lib_path[0]}"/crtn.o \
+    -l hooligan -L./bin

--- a/bin/hcli
+++ b/bin/hcli
@@ -31,7 +31,7 @@ clean() {
 }
 
 clean_assembly() {
-    find . -name '*.s' -exec rm {} +
+    rm -f ./*.s
 }
 
 COMPILER_GENERATED=0
@@ -47,7 +47,16 @@ compile() {
 
 generate_executable() {
     compile "$@"
-    cc ./*.s -no-pie -g -O0 -lhooligan -L./bin
+    rm -f ./*.o
+    find ./*.s | while read -r fn; do
+        as -c "$fn" -o ${fn%.s}.o
+    done
+    ld -o a.out -m elf_x86_64 /usr/lib/x86_64-linux-gnu/crt1.o /usr/lib/x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/7/crtbegin.o \
+        -L/usr/lib/x86_64-linux-gnu -L/usr/lib64 -L/lib64 \
+        -L/usr/lib/gcc/x86_64-linux-gnu/7 -dynamic-linker /lib64/ld-linux-x86-64.so.2 ./*.o \
+        -lc -lgcc --as-needed -lgcc_s --no-as-needed \
+        /usr/lib/gcc/x86_64-linux-gnu/7/crtend.o /usr/lib/x86_64-linux-gnu/crtn.o \
+        -l hooligan -L./bin
 }
 
 # コマンドの実行結果と標準出力を同時にテストする方法が思いつかない
@@ -60,7 +69,7 @@ runtest() {
         expectedout=$(cat "$dn"/out)
         set +e
         stdout=$(./a.out)
-        if [[ $? -eq 0 ]] && [ "$stdout" == "$expectedout" ]; then  
+        if [[ $? -eq 0 ]] && [ "$stdout" == "$expectedout" ]; then
             echo ...passed
         else
             echo ...failed

--- a/bin/hcli
+++ b/bin/hcli
@@ -45,20 +45,9 @@ compile() {
     fi
 }
 
-lib_path=($(dirname /usr/lib/x86_64-linux-gnu/crti.o))
-gcc_lib_path=($(dirname /usr/lib/gcc/x86_64-linux-gnu/*/crtbegin.o))
 generate_executable() {
     compile "$@"
-    rm -f ./*.o
-    find ./*.s | while read -r fn; do
-        as -c "$fn" -o "${fn%.s}".o
-    done
-    ld -o a.out -m elf_x86_64 "${lib_path[0]}"/crt1.o "${lib_path[0]}"/crti.o "${gcc_lib_path[0]}"/crtbegin.o \
-        -L"${lib_path[0]}" -L/usr/lib64 -L/lib64 \
-        -L"${gcc_lib_path[0]}" -dynamic-linker /lib64/ld-linux-x86-64.so.2 ./*.o \
-        -lc -lgcc --as-needed -lgcc_s --no-as-needed \
-        "${gcc_lib_path[0]}"/crtend.o "${lib_path[0]}"/crtn.o \
-        -l hooligan -L./bin
+    ./bin/assemble.sh
 }
 
 # コマンドの実行結果と標準出力を同時にテストする方法が思いつかない

--- a/bin/hcli
+++ b/bin/hcli
@@ -45,17 +45,19 @@ compile() {
     fi
 }
 
+lib_path=($(dirname /usr/lib/x86_64-linux-gnu/crti.o))
+gcc_lib_path=($(dirname /usr/lib/gcc/x86_64-linux-gnu/*/crtbegin.o))
 generate_executable() {
     compile "$@"
     rm -f ./*.o
     find ./*.s | while read -r fn; do
-        as -c "$fn" -o ${fn%.s}.o
+        as -c "$fn" -o "${fn%.s}".o
     done
-    ld -o a.out -m elf_x86_64 /usr/lib/x86_64-linux-gnu/crt1.o /usr/lib/x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/7/crtbegin.o \
-        -L/usr/lib/x86_64-linux-gnu -L/usr/lib64 -L/lib64 \
-        -L/usr/lib/gcc/x86_64-linux-gnu/7 -dynamic-linker /lib64/ld-linux-x86-64.so.2 ./*.o \
+    ld -o a.out -m elf_x86_64 "${lib_path[0]}"/crt1.o "${lib_path[0]}"/crti.o "${gcc_lib_path[0]}"/crtbegin.o \
+        -L"${lib_path[0]}" -L/usr/lib64 -L/lib64 \
+        -L"${gcc_lib_path[0]}" -dynamic-linker /lib64/ld-linux-x86-64.so.2 ./*.o \
         -lc -lgcc --as-needed -lgcc_s --no-as-needed \
-        /usr/lib/gcc/x86_64-linux-gnu/7/crtend.o /usr/lib/x86_64-linux-gnu/crtn.o \
+        "${gcc_lib_path[0]}"/crtend.o "${lib_path[0]}"/crtn.o \
         -l hooligan -L./bin
 }
 


### PR DESCRIPTION
In gcc 7.5.0(Ubuntu 18.04), -fPIC option is necessary to create .so file.
So, I suggest to appned -fPIC option.