### PR TITLE
introduce args List for refactoring

### DIFF
--- a/src/generator.c
+++ b/src/generator.c
@@ -112,20 +112,19 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         gen_builtin_function(node);
         return;
     }
-    Node *arg = node->next_arg;
-    Node *first_arg = NULL;
+
     bool isfloat[6];
     int count = 0;
     int num_of_float_arg = 0;
-    while (arg != NULL)
+    for (int i = 0; i < node->args->size; i++)
     {
+        Node *arg = (Node *)node->args->elm[i];
         if (arg->kind != ND_ARG)
         {
             error("引数ではありません");
         }
         gen(arg->child);
-
-        if (count >= 6)
+        if (i >= 6)
         {
             error("引数の数が多すぎます");
         }
@@ -138,7 +137,6 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         {
             isfloat[count] = false;
         }
-        arg = arg->next_arg;
         count++;
     }
     while (count > 0)

--- a/src/generator.c
+++ b/src/generator.c
@@ -112,7 +112,7 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         gen_builtin_function(node);
         return;
     }
-    Node *arg = node->next;
+    Node *arg = node->next_arg;
     Node *first_arg = NULL;
     bool isfloat[6];
     int count = 0;
@@ -138,7 +138,7 @@ static void gen_function(Node *node) // gen_function_callとかのほうがい�
         {
             isfloat[count] = false;
         }
-        arg = arg->next;
+        arg = arg->next_arg;
         count++;
     }
     while (count > 0)

--- a/src/generator/builtin.c
+++ b/src/generator/builtin.c
@@ -6,7 +6,7 @@ static void gen_va_start(Node *node)
     {
         error("va_startではありません");
     }
-    Node *first_arg = node->next->child;
+    Node *first_arg = node->next_arg->child;
     new_il_sentence_raw("  mov DWORD PTR -72[rbp], 8");  // TODO 本当は第二引数から計算しないといけない
     new_il_sentence_raw("  mov DWORD PTR -68[rbp], 48"); // va_list->fp_offset
     new_il_sentence_raw("  lea rax, 16[rbp]");
@@ -25,8 +25,8 @@ static void gen_va_arg(Node *node)
     {
         error("va_argではありません");
     }
-    Node *first_arg = node->next->child;
-    Node *second_arg = node->next->next->child;
+    Node *first_arg = node->next_arg->child;
+    Node *second_arg = node->next_arg->next_arg->child;
     if (second_arg->kind != ND_TYPE)
     {
         error("va_argの第2引数には型を指定してください");

--- a/src/generator/builtin.c
+++ b/src/generator/builtin.c
@@ -6,7 +6,7 @@ static void gen_va_start(Node *node)
     {
         error("va_startではありません");
     }
-    Node *first_arg = node->next_arg->child;
+    Node *first_arg = ((Node *)node->args->elm[0])->child;
     new_il_sentence_raw("  mov DWORD PTR -72[rbp], 8");  // TODO 本当は第二引数から計算しないといけない
     new_il_sentence_raw("  mov DWORD PTR -68[rbp], 48"); // va_list->fp_offset
     new_il_sentence_raw("  lea rax, 16[rbp]");
@@ -25,8 +25,8 @@ static void gen_va_arg(Node *node)
     {
         error("va_argではありません");
     }
-    Node *first_arg = node->next_arg->child;
-    Node *second_arg = node->next_arg->next_arg->child;
+    Node *first_arg = ((Node *)node->args->elm[0])->child;
+    Node *second_arg = ((Node *)node->args->elm[1])->child;
     if (second_arg->kind != ND_TYPE)
     {
         error("va_argの第2引数には型を指定してください");

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -225,7 +225,6 @@ struct Node
     // for function
     List *args;
     int args_region_size;
-    int num_args;
     bool is_void;
     bool has_variable_length_arguments;
 

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -206,7 +206,6 @@ struct Node
     Node *child;
     // for
     Node *next;
-    Node *next_arg;
 
     // for(init; condition; on_end) body;
     Node *init;
@@ -224,6 +223,7 @@ struct Node
     // for static
     bool is_static;
     // for function
+    List *args;
     int args_region_size;
     int num_args;
     bool is_void;

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -225,7 +225,6 @@ struct Node
     // for function
     List *args;
     int args_region_size;
-    bool is_void;
     bool has_variable_length_arguments;
 
     // for float

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -224,7 +224,6 @@ struct Node
     bool is_static;
     // for function
     int args_region_size;
-    Node *args;
     int num_args;
     bool is_void;
     bool has_variable_length_arguments;

--- a/src/hooligan.h
+++ b/src/hooligan.h
@@ -206,6 +206,7 @@ struct Node
     Node *child;
     // for
     Node *next;
+    Node *next_arg;
 
     // for(init; condition; on_end) body;
     Node *init;

--- a/src/parser.c
+++ b/src/parser.c
@@ -46,10 +46,10 @@ static Node *ident()
             node->name = func->name;
             node->length = func->length;
             node->ty = func->ty;
-            node->num_args = func->num_args;
             node->is_static = func->is_static;
             node->has_variable_length_arguments = func->has_variable_length_arguments;
-            if (node->num_args != 0 && func->arg_ty_ls[0]->ty == VOID)
+            int args_count = func->num_args;
+            if (args_count != 0 && func->arg_ty_ls[0]->ty == VOID)
             {
                 node->is_void = true;
             }
@@ -63,7 +63,7 @@ static Node *ident()
                 if (count > 0)
                     expect(",");
 
-                if (count < node->num_args || node->has_variable_length_arguments)
+                if (count < args_count || node->has_variable_length_arguments)
                 {
                     if (node->is_void)
                     {
@@ -77,7 +77,7 @@ static Node *ident()
                 }
                 count++;
             }
-            if (!(node->is_void) && count < node->num_args)
+            if (!(node->is_void) && count < args_count)
             {
                 error("引数が少なすぎます");
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -49,14 +49,7 @@ static Node *ident()
             node->is_static = func->is_static;
             node->has_variable_length_arguments = func->has_variable_length_arguments;
             int args_count = func->num_args;
-            if (args_count != 0 && func->arg_ty_ls[0]->ty == VOID)
-            {
-                node->is_void = true;
-            }
-            else
-            {
-                node->is_void = false;
-            }
+            bool is_arg_forbidden = args_count != 0 && func->arg_ty_ls[0]->ty == VOID;
 
             while (!consume(")"))
             {
@@ -65,7 +58,7 @@ static Node *ident()
 
                 if (count < args_count || node->has_variable_length_arguments)
                 {
-                    if (node->is_void)
+                    if (is_arg_forbidden)
                     {
                         error("引数は予期されていません");
                     }
@@ -77,7 +70,7 @@ static Node *ident()
                 }
                 count++;
             }
-            if (!(node->is_void) && count < args_count)
+            if (!is_arg_forbidden && count < args_count)
             {
                 error("引数が少なすぎます");
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -71,7 +71,7 @@ static Node *ident()
                         error("引数は予期されていません");
                     }
                     Node *arg = new_node_single(ND_ARG, expr());
-                    arg_top->next = arg;
+                    arg_top->next_arg = arg;
                     arg_top = arg;
                 }
                 else
@@ -96,7 +96,7 @@ static Node *ident()
                     expect(",");
 
                 Node *arg = new_node_single(ND_ARG, expr());
-                arg_top->next = arg;
+                arg_top->next_arg = arg;
                 arg_top = arg;
 
                 count++;

--- a/src/parser.c
+++ b/src/parser.c
@@ -51,25 +51,20 @@ static Node *ident()
             int args_count = func->num_args;
             bool is_arg_forbidden = args_count != 0 && func->arg_ty_ls[0]->ty == VOID;
 
-            while (!consume(")"))
+            for (; !consume(")"); consume(","))
             {
-                if (count > 0)
-                    expect(",");
-
+                if (is_arg_forbidden)
+                {
+                    error("引数は予期されていません");
+                }
+                Node *arg = new_node_single(ND_ARG, expr());
                 if (count < args_count || node->has_variable_length_arguments)
                 {
-                    if (is_arg_forbidden)
-                    {
-                        error("引数は予期されていません");
-                    }
-                    node->args = append(node->args, new_node_single(ND_ARG, expr()));
-                }
-                else
-                {
-                    expr();
+                    node->args = append(node->args, arg);
                 }
                 count++;
             }
+
             if (!is_arg_forbidden && count < args_count)
             {
                 error("引数が少なすぎます");

--- a/src/parser.c
+++ b/src/parser.c
@@ -39,7 +39,6 @@ static Node *ident()
     {
         Node *node = new_node_raw(ND_FUNC);
         Var *func = find_var(ident);
-        Node *arg_top = node;
         int count = 0;
 
         if (func)
@@ -70,9 +69,7 @@ static Node *ident()
                     {
                         error("引数は予期されていません");
                     }
-                    Node *arg = new_node_single(ND_ARG, expr());
-                    arg_top->next_arg = arg;
-                    arg_top = arg;
+                    node->args = append(node->args, new_node_single(ND_ARG, expr()));
                 }
                 else
                 {
@@ -95,10 +92,7 @@ static Node *ident()
                 if (count > 0)
                     expect(",");
 
-                Node *arg = new_node_single(ND_ARG, expr());
-                arg_top->next_arg = arg;
-                arg_top = arg;
-
+                node->args = append(node->args, new_node_single(ND_ARG, expr()));
                 count++;
             }
         }

--- a/src/parser/node_constructor.c
+++ b/src/parser/node_constructor.c
@@ -6,6 +6,7 @@ static Node *new_node_raw(NodeKind kind)
     Node *node = calloc(1, sizeof(Node));
     node->kind = kind;
     node->id = id++;
+    node->args = new_list(10);
     logging(node);
     return node;
 }


### PR DESCRIPTION
Previously, `next` member of struct Node is used for function's arguments.
I add args field and replace.